### PR TITLE
SOF-1963: iNews story changes are classified and emitted.

### DIFF
--- a/src/business-logic/entities/inews-story.ts
+++ b/src/business-logic/entities/inews-story.ts
@@ -6,6 +6,7 @@ export interface InewsStory {
   readonly versionLocator: string
   readonly metadata: Readonly<Record<string, string>>
   readonly cues: readonly InewsCue[]
+  readonly rank: number
 }
 
 export interface InewsCue {

--- a/src/business-logic/facades/service-facade.ts
+++ b/src/business-logic/facades/service-facade.ts
@@ -18,6 +18,10 @@ import { InewsQueueDiffer } from '../interfaces/inews-queue-differ'
 import { InewsQueueDifferImplementation } from '../services/inews-queue-differ-implementation'
 import { InewsIdParser } from '../interfaces/inews-id-parser'
 import { InewsIdParserImplementation } from '../services/inews-id-parser-implementation'
+import { InewsQueueRepository } from '../interfaces/inews-queue-repository'
+import { InMemoryInewsQueueRepository } from '../services/in-memory-inews-queue-repository'
+import { InewsStoryRankResolver } from '../interfaces/inews-story-rank-resolver'
+import { InewsStoryRankResolverImplementation } from '../services/inews-story-rank-resolver-implementation'
 
 export class ServiceFacade {
   public static createApplicationConfigurationService(): ApplicationConfigurationService {
@@ -33,6 +37,8 @@ export class ServiceFacade {
       DomainEventFacade.createInewsQueuePoolObserver(),
       DomainEventFacade.createInewsQueueEmitter(),
       this.createInewsQueueDiffer(),
+      this.createInewsQueueRepository(),
+      this.createInewsStoryRankResolver(),
       LoggerFacade.createLogger(),
     )
   }
@@ -56,5 +62,13 @@ export class ServiceFacade {
 
   public static createInewsIdParser(): InewsIdParser {
     return new InewsIdParserImplementation()
+  }
+
+  public static createInewsQueueRepository(): InewsQueueRepository {
+    return new InMemoryInewsQueueRepository()
+  }
+
+  public static createInewsStoryRankResolver(): InewsStoryRankResolver {
+    return new InewsStoryRankResolverImplementation()
   }
 }

--- a/src/business-logic/facades/service-facade.ts
+++ b/src/business-logic/facades/service-facade.ts
@@ -14,6 +14,8 @@ import { DomainEventFacade } from './domain-event-facade'
 import { InewsStoryParser } from '../interfaces/inews-story-parser'
 import { NsmlInewsStoryParser } from '../services/nsml-inews-story-parser'
 import { RegExpNsmlParser } from '../services/reg-exp-nsml-parser'
+import { InewsQueueDiffer } from '../interfaces/inews-queue-differ'
+import { InewsQueueDifferImplementation } from '../services/inews-queue-differ-implementation'
 import { InewsIdParser } from '../interfaces/inews-id-parser'
 import { InewsIdParserImplementation } from '../services/inews-id-parser-implementation'
 
@@ -30,6 +32,7 @@ export class ServiceFacade {
       DomainEventFacade.createConnectionStateEmitter(),
       DomainEventFacade.createInewsQueuePoolObserver(),
       DomainEventFacade.createInewsQueueEmitter(),
+      this.createInewsQueueDiffer(),
       LoggerFacade.createLogger(),
     )
   }
@@ -45,6 +48,10 @@ export class ServiceFacade {
 
   public static createInewsTimestampParser(): InewsTimestampParser {
     return new InewsFtpTimestampParser()
+  }
+
+  public static createInewsQueueDiffer(): InewsQueueDiffer {
+    return new InewsQueueDifferImplementation()
   }
 
   public static createInewsIdParser(): InewsIdParser {

--- a/src/business-logic/factories/entity-test-factory.ts
+++ b/src/business-logic/factories/entity-test-factory.ts
@@ -32,11 +32,12 @@ export class EntityTestFactory {
       versionLocator: this.generateRandomId(),
       metadata: {},
       cues: [],
+      rank: 0,
       ...partialInewsStory,
     }
   }
 
-  public static createInewsId(partialInewsId: Partial<InewsId>): InewsId {
+  public static createInewsId(partialInewsId: Partial<InewsId> = {}): InewsId {
     return {
       storyId: partialInewsId.storyId?.toUpperCase() ?? this.generateRandomId(),
       contentLocator: partialInewsId.contentLocator?.toUpperCase() ?? this.generateRandomId(),

--- a/src/business-logic/factories/entity-test-factory.ts
+++ b/src/business-logic/factories/entity-test-factory.ts
@@ -1,0 +1,46 @@
+import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
+import { InewsStory } from '../entities/inews-story'
+import { InewsId } from '../entities/inews-id'
+
+export class EntityTestFactory {
+  public static createInewsStoryMetadata(partialInewsStoryMetadata: Partial<InewsStoryMetadata> = {}): InewsStoryMetadata {
+    return {
+      id: this.generateRandomId(),
+      name: 'Story name',
+      queueId: this.generateQueueId(),
+      contentLocator: this.generateRandomId(),
+      versionLocator: this.generateRandomId(),
+      modifiedAtEpochTime: Date.now(),
+      ...partialInewsStoryMetadata,
+    }
+  }
+
+  private static generateQueueId(): string {
+    return 'QUEUE1'
+  }
+
+  private static generateRandomId(): string {
+    return crypto.randomUUID()
+  }
+
+  public static createInewsStory(partialInewsStory: Partial<InewsStory> = {}): InewsStory {
+    return {
+      id: this.generateRandomId(),
+      name: 'Story name',
+      queueId: this.generateQueueId(),
+      contentLocator: this.generateRandomId(),
+      versionLocator: this.generateRandomId(),
+      metadata: {},
+      cues: [],
+      ...partialInewsStory,
+    }
+  }
+
+  public static createInewsId(partialInewsId: Partial<InewsId>): InewsId {
+    return {
+      storyId: partialInewsId.storyId?.toUpperCase() ?? this.generateRandomId(),
+      contentLocator: partialInewsId.contentLocator?.toUpperCase() ?? this.generateRandomId(),
+      versionLocator: partialInewsId.versionLocator?.toUpperCase() ?? this.generateRandomId(),
+    }
+  }
+}

--- a/src/business-logic/factories/entity-test-factory.ts
+++ b/src/business-logic/factories/entity-test-factory.ts
@@ -20,7 +20,7 @@ export class EntityTestFactory {
   }
 
   private static generateRandomId(): string {
-    return crypto.randomUUID()
+    return crypto.randomUUID().toUpperCase()
   }
 
   public static createInewsStory(partialInewsStory: Partial<InewsStory> = {}): InewsStory {

--- a/src/business-logic/interfaces/inews-client.ts
+++ b/src/business-logic/interfaces/inews-client.ts
@@ -1,11 +1,12 @@
 import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
 import { ConnectionState } from '../../data-access/value-objects/connection-state'
 import { InewsStory } from '../entities/inews-story'
+import { InewsId } from '../entities/inews-id'
 
 export interface InewsClient {
   connect(): Promise<void>
   getStoryMetadataForQueue(queueId: string): Promise<readonly InewsStoryMetadata[]>
-  getStory(queueId: string, storyId: string): Promise<InewsStory>
+  getStory(queueId: string, inewsId: InewsId): Promise<InewsStory>
   subscribeToConnectionState(onConnectionStateChangedCallback: (connectionState: ConnectionState) => void): void
   disconnect(): Promise<void>
 }

--- a/src/business-logic/interfaces/inews-queue-differ.ts
+++ b/src/business-logic/interfaces/inews-queue-differ.ts
@@ -1,0 +1,9 @@
+import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
+import { InewsStory } from '../entities/inews-story'
+
+export interface InewsQueueDiffer {
+  getMetadataForUncachedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[]
+  getMetadataForStoriesWithChangedContent(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[]
+  getMetadataForMovedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[]
+  getDeletedStoryIds(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly string[]
+}

--- a/src/business-logic/interfaces/inews-queue-differ.ts
+++ b/src/business-logic/interfaces/inews-queue-differ.ts
@@ -2,8 +2,8 @@ import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
 import { InewsStory } from '../entities/inews-story'
 
 export interface InewsQueueDiffer {
-  getMetadataForUncachedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[]
-  getMetadataForStoriesWithChangedContent(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[]
-  getMetadataForMovedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[]
-  getDeletedStoryIds(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly string[]
+  getMetadataForUncachedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[]
+  getMetadataForStoriesWithChangedContent(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[]
+  getMetadataForMovedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[]
+  getDeletedStoryIds(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly string[]
 }

--- a/src/business-logic/interfaces/inews-queue-repository.ts
+++ b/src/business-logic/interfaces/inews-queue-repository.ts
@@ -1,0 +1,6 @@
+import { InewsQueue } from '../entities/inews-queue'
+
+export interface InewsQueueRepository {
+  getInewsQueue(inewsQueueId: string): InewsQueue
+  setInewsQueue(inewsQueue: InewsQueue): void
+}

--- a/src/business-logic/interfaces/inews-story-parser.ts
+++ b/src/business-logic/interfaces/inews-story-parser.ts
@@ -1,5 +1,6 @@
 import { InewsStory } from '../entities/inews-story'
+import { InewsId } from '../entities/inews-id'
 
 export interface InewsStoryParser {
-  parseInewsStory(nsmlText: string, queueId: string): InewsStory
+  parseInewsStory(nsmlText: string, queueId: string, inewsId: InewsId): InewsStory
 }

--- a/src/business-logic/interfaces/inews-story-rank-resolver.ts
+++ b/src/business-logic/interfaces/inews-story-rank-resolver.ts
@@ -1,0 +1,6 @@
+import { InewsStory } from '../entities/inews-story'
+import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
+
+export interface InewsStoryRankResolver {
+  getInewsStoryRanks(inewsStoryMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): ReadonlyMap<string, number>
+}

--- a/src/business-logic/services/ftp-inews-client.ts
+++ b/src/business-logic/services/ftp-inews-client.ts
@@ -81,9 +81,9 @@ export class FtpInewsClient implements InewsClient {
     await this.ftpClient.changeWorkingDirectory(path)
   }
 
-  public async getStory(queueId: string, storyId: string): Promise<InewsStory> {
+  public async getStory(queueId: string, inewsId: InewsId): Promise<InewsStory> {
     await this.setWorkingDirectory(queueId)
-    return this.inewsStoryParser.parseInewsStory(await this.ftpClient.getFile(storyId), queueId)
+    return this.inewsStoryParser.parseInewsStory(await this.ftpClient.getFile(inewsId.storyId), queueId, inewsId)
   }
 
   public subscribeToConnectionState(onConnectionStateChangedCallback: (connectionState: ConnectionState) => void): void {

--- a/src/business-logic/services/in-memory-inews-queue-repository.ts
+++ b/src/business-logic/services/in-memory-inews-queue-repository.ts
@@ -1,0 +1,18 @@
+import { InewsQueueRepository } from '../interfaces/inews-queue-repository'
+import { InewsQueue } from '../entities/inews-queue'
+
+export class InMemoryInewsQueueRepository implements InewsQueueRepository {
+  private readonly inewsQueues: Map<string, InewsQueue> = new Map()
+
+  public getInewsQueue(inewsQueueId: string): InewsQueue {
+    const inewsQueue: InewsQueue | undefined = this.inewsQueues.get(inewsQueueId)
+    if (!inewsQueue) {
+      throw new Error(`Unable to find an iNews queue with id '${inewsQueueId}'.`)
+    }
+    return inewsQueue
+  }
+
+  public setInewsQueue(inewsQueue: InewsQueue): void {
+    this.inewsQueues.set(inewsQueue.id, inewsQueue)
+  }
+}

--- a/src/business-logic/services/inews-queue-differ-implementation.spec.ts
+++ b/src/business-logic/services/inews-queue-differ-implementation.spec.ts
@@ -5,23 +5,21 @@ import { EntityTestFactory } from '../factories/entity-test-factory'
 
 describe(InewsQueueDifferImplementation.name, () => {
   describe(InewsQueueDifferImplementation.prototype.getMetadataForUncachedStories, () => {
-    describe('when all stories are cached', () => {
-      it('returns an empty array', () => {
-        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata] = [
-          EntityTestFactory.createInewsStoryMetadata(),
-          EntityTestFactory.createInewsStoryMetadata(),
-        ]
-        const cachedStories: Readonly<Record<string, InewsStory>> = {
-          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
-          [storyMetadataSequence[1].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[1]),
-        }
-        const testee: InewsQueueDifferImplementation = createTestee()
+    describe('when all stories are cached', () => it('returns an empty array', () => {
+      const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata] = [
+        EntityTestFactory.createInewsStoryMetadata(),
+        EntityTestFactory.createInewsStoryMetadata(),
+      ]
+      const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+        [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory(storyMetadataSequence[0])],
+        [storyMetadataSequence[1].id, EntityTestFactory.createInewsStory(storyMetadataSequence[1])],
+      ])
+      const testee: InewsQueueDifferImplementation = createTestee()
 
-        const result: readonly InewsStoryMetadata[] = testee.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
+      const result: readonly InewsStoryMetadata[] = testee.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
 
-        expect(result).toMatchObject([])
-      })
-    })
+      expect(result).toMatchObject([])
+    }))
 
     describe('when some stories are uncached', () => {
       it('returns metadata for the uncached stories', () => {
@@ -30,10 +28,10 @@ describe(InewsQueueDifferImplementation.name, () => {
           EntityTestFactory.createInewsStoryMetadata(),
           EntityTestFactory.createInewsStoryMetadata(),
         ]
-        const cachedStories: Readonly<Record<string, InewsStory>> = {
-          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
-          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
-        }
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+          [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory(storyMetadataSequence[0])],
+          [storyMetadataSequence[2].id, EntityTestFactory.createInewsStory(storyMetadataSequence[2])],
+        ])
         const testee: InewsQueueDifferImplementation = createTestee()
 
         const result: readonly InewsStoryMetadata[] = testee.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
@@ -50,10 +48,10 @@ describe(InewsQueueDifferImplementation.name, () => {
           EntityTestFactory.createInewsStoryMetadata(),
           EntityTestFactory.createInewsStoryMetadata(),
         ]
-        const cachedStories: Readonly<Record<string, InewsStory>> = {
-          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
-          [storyMetadataSequence[1].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[1]),
-        }
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+          [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory(storyMetadataSequence[0])],
+          [storyMetadataSequence[1].id, EntityTestFactory.createInewsStory(storyMetadataSequence[1])],
+        ])
         const testee: InewsQueueDifferImplementation = createTestee()
 
         const result: readonly InewsStoryMetadata[] = testee.getMetadataForStoriesWithChangedContent(storyMetadataSequence, cachedStories)
@@ -69,11 +67,11 @@ describe(InewsQueueDifferImplementation.name, () => {
           EntityTestFactory.createInewsStoryMetadata(),
           EntityTestFactory.createInewsStoryMetadata(),
         ]
-        const cachedStories: Readonly<Record<string, InewsStory>> = {
-          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], contentLocator: 'oldContent', versionLocator: 'oldVersion' }),
-          [storyMetadataSequence[1].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[1]),
-          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
-        }
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+          [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], contentLocator: 'oldContent', versionLocator: 'oldVersion' })],
+          [storyMetadataSequence[1].id, EntityTestFactory.createInewsStory(storyMetadataSequence[1])],
+          [storyMetadataSequence[2].id, EntityTestFactory.createInewsStory(storyMetadataSequence[2])],
+        ])
         const testee: InewsQueueDifferImplementation = createTestee()
 
         const result: readonly InewsStoryMetadata[] = testee.getMetadataForStoriesWithChangedContent(storyMetadataSequence, cachedStories)
@@ -85,7 +83,7 @@ describe(InewsQueueDifferImplementation.name, () => {
     describe('when the story version is changed but not the content', () => {
       it('ignores the story', () => {
         const cachedInewsStoryMetadata: InewsStoryMetadata = EntityTestFactory.createInewsStoryMetadata()
-        const cachedStories: Readonly<Record<string, InewsStory>> = { [cachedInewsStoryMetadata.id]: EntityTestFactory.createInewsStory(cachedInewsStoryMetadata) }
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([[cachedInewsStoryMetadata.id, EntityTestFactory.createInewsStory(cachedInewsStoryMetadata)]])
         const updatedInewsStoryMetadata: InewsStoryMetadata = {
           ...cachedInewsStoryMetadata,
           versionLocator: 'newVersion',
@@ -105,9 +103,9 @@ describe(InewsQueueDifferImplementation.name, () => {
       describe('when the content locator is unchanged', () => {
         it('classifies the story as moved', () => {
           const storyMetadataSequence: readonly [InewsStoryMetadata] = [EntityTestFactory.createInewsStoryMetadata()]
-          const cachedStories: Readonly<Record<string, InewsStory>> = {
-            [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], versionLocator: 'newVersion' }),
-          }
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], versionLocator: 'newVersion' })],
+          ])
           const testee: InewsQueueDifferImplementation = createTestee()
 
           const result: readonly InewsStoryMetadata[] = testee.getMetadataForMovedStories(storyMetadataSequence, cachedStories)
@@ -119,9 +117,9 @@ describe(InewsQueueDifferImplementation.name, () => {
       describe('when the content locator is changed', () => {
         it('ignores the story', () => {
           const storyMetadataSequence: readonly [InewsStoryMetadata] = [EntityTestFactory.createInewsStoryMetadata()]
-          const cachedStories: Readonly<Record<string, InewsStory>> = {
-            [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], contentLocator: 'newContent', versionLocator: 'newVersion' }),
-          }
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], contentLocator: 'newContent', versionLocator: 'newVersion' })],
+          ])
           const testee: InewsQueueDifferImplementation = createTestee()
 
           const result: readonly InewsStoryMetadata[] = testee.getMetadataForMovedStories(storyMetadataSequence, cachedStories)
@@ -140,10 +138,10 @@ describe(InewsQueueDifferImplementation.name, () => {
           EntityTestFactory.createInewsStoryMetadata(),
           EntityTestFactory.createInewsStoryMetadata(),
         ]
-        const cachedStories: Readonly<Record<string, InewsStory>> = {
-          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
-          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
-        }
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+          [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory(storyMetadataSequence[0])],
+          [storyMetadataSequence[2].id, EntityTestFactory.createInewsStory(storyMetadataSequence[2])],
+        ])
         const testee: InewsQueueDifferImplementation = createTestee()
 
         const result: readonly string[] = testee.getDeletedStoryIds(storyMetadataSequence, cachedStories)
@@ -164,13 +162,13 @@ describe(InewsQueueDifferImplementation.name, () => {
           EntityTestFactory.createInewsStory(),
           EntityTestFactory.createInewsStory(),
         ]
-        const cachedStories: Readonly<Record<string, InewsStory>> = {
-          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
-          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
-          [deletedStories[0].id]: deletedStories[0],
-          [deletedStories[1].id]: deletedStories[1],
-          [deletedStories[2].id]: deletedStories[2],
-        }
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+          [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory(storyMetadataSequence[0])],
+          [storyMetadataSequence[2].id, EntityTestFactory.createInewsStory(storyMetadataSequence[2])],
+          [deletedStories[0].id, deletedStories[0]],
+          [deletedStories[1].id, deletedStories[1]],
+          [deletedStories[2].id, deletedStories[2]],
+        ])
         const testee: InewsQueueDifferImplementation = createTestee()
 
         const result: readonly string[] = testee.getDeletedStoryIds(storyMetadataSequence, cachedStories)

--- a/src/business-logic/services/inews-queue-differ-implementation.spec.ts
+++ b/src/business-logic/services/inews-queue-differ-implementation.spec.ts
@@ -1,0 +1,186 @@
+import { InewsQueueDifferImplementation } from './inews-queue-differ-implementation'
+import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
+import { InewsStory } from '../entities/inews-story'
+import { EntityTestFactory } from '../factories/entity-test-factory'
+
+describe(InewsQueueDifferImplementation.name, () => {
+  describe(InewsQueueDifferImplementation.prototype.getMetadataForUncachedStories, () => {
+    describe('when all stories are cached', () => {
+      it('returns an empty array', () => {
+        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const cachedStories: Readonly<Record<string, InewsStory>> = {
+          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
+          [storyMetadataSequence[1].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[1]),
+        }
+        const testee: InewsQueueDifferImplementation = createTestee()
+
+        const result: readonly InewsStoryMetadata[] = testee.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
+
+        expect(result).toMatchObject([])
+      })
+    })
+
+    describe('when some stories are uncached', () => {
+      it('returns metadata for the uncached stories', () => {
+        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const cachedStories: Readonly<Record<string, InewsStory>> = {
+          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
+          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
+        }
+        const testee: InewsQueueDifferImplementation = createTestee()
+
+        const result: readonly InewsStoryMetadata[] = testee.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
+
+        expect(result).toMatchObject([storyMetadataSequence[1]])
+      })
+    })
+  })
+
+  describe(InewsQueueDifferImplementation.prototype.getMetadataForStoriesWithChangedContent, () => {
+    describe('when no stories have content changes', () => {
+      it('returns empty array', () => {
+        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const cachedStories: Readonly<Record<string, InewsStory>> = {
+          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
+          [storyMetadataSequence[1].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[1]),
+        }
+        const testee: InewsQueueDifferImplementation = createTestee()
+
+        const result: readonly InewsStoryMetadata[] = testee.getMetadataForStoriesWithChangedContent(storyMetadataSequence, cachedStories)
+
+        expect(result).toMatchObject([])
+      })
+    })
+
+    describe('when some stories have changed content', () => {
+      it('returns metadata for the changed stories', () => {
+        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const cachedStories: Readonly<Record<string, InewsStory>> = {
+          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], contentLocator: 'oldContent', versionLocator: 'oldVersion' }),
+          [storyMetadataSequence[1].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[1]),
+          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
+        }
+        const testee: InewsQueueDifferImplementation = createTestee()
+
+        const result: readonly InewsStoryMetadata[] = testee.getMetadataForStoriesWithChangedContent(storyMetadataSequence, cachedStories)
+
+        expect(result).toMatchObject([storyMetadataSequence[0]])
+      })
+    })
+
+    describe('when the story version is changed but not the content', () => {
+      it('ignores the story', () => {
+        const cachedInewsStoryMetadata: InewsStoryMetadata = EntityTestFactory.createInewsStoryMetadata()
+        const cachedStories: Readonly<Record<string, InewsStory>> = { [cachedInewsStoryMetadata.id]: EntityTestFactory.createInewsStory(cachedInewsStoryMetadata) }
+        const updatedInewsStoryMetadata: InewsStoryMetadata = {
+          ...cachedInewsStoryMetadata,
+          versionLocator: 'newVersion',
+        }
+        const storyMetadataSequence: readonly [InewsStoryMetadata] = [updatedInewsStoryMetadata]
+        const testee: InewsQueueDifferImplementation = createTestee()
+
+        const result: readonly InewsStoryMetadata[] = testee.getMetadataForStoriesWithChangedContent(storyMetadataSequence, cachedStories)
+
+        expect(result).toMatchObject([])
+      })
+    })
+  })
+
+  describe(InewsQueueDifferImplementation.prototype.getMetadataForMovedStories.name, () => {
+    describe('when a story has a changed version locator', () => {
+      describe('when the content locator is unchanged', () => {
+        it('classifies the story as moved', () => {
+          const storyMetadataSequence: readonly [InewsStoryMetadata] = [EntityTestFactory.createInewsStoryMetadata()]
+          const cachedStories: Readonly<Record<string, InewsStory>> = {
+            [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], versionLocator: 'newVersion' }),
+          }
+          const testee: InewsQueueDifferImplementation = createTestee()
+
+          const result: readonly InewsStoryMetadata[] = testee.getMetadataForMovedStories(storyMetadataSequence, cachedStories)
+
+          expect(result).toMatchObject([storyMetadataSequence[0]])
+        })
+      })
+
+      describe('when the content locator is changed', () => {
+        it('ignores the story', () => {
+          const storyMetadataSequence: readonly [InewsStoryMetadata] = [EntityTestFactory.createInewsStoryMetadata()]
+          const cachedStories: Readonly<Record<string, InewsStory>> = {
+            [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory({ ...storyMetadataSequence[0], contentLocator: 'newContent', versionLocator: 'newVersion' }),
+          }
+          const testee: InewsQueueDifferImplementation = createTestee()
+
+          const result: readonly InewsStoryMetadata[] = testee.getMetadataForMovedStories(storyMetadataSequence, cachedStories)
+
+          expect(result).toMatchObject([])
+        })
+      })
+    })
+  })
+
+  describe(InewsQueueDifferImplementation.prototype.getDeletedStoryIds.name, () => {
+    describe('when no stories are deleted', () => {
+      it('returns an empty array', () => {
+        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const cachedStories: Readonly<Record<string, InewsStory>> = {
+          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
+          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
+        }
+        const testee: InewsQueueDifferImplementation = createTestee()
+
+        const result: readonly string[] = testee.getDeletedStoryIds(storyMetadataSequence, cachedStories)
+
+        expect(result).toMatchObject([])
+      })
+    })
+
+    describe('when stories have been deleted', () => {
+      it('returns the ids for the deleted stories', () => {
+        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const deletedStories: readonly [InewsStory, InewsStory, InewsStory] = [
+          EntityTestFactory.createInewsStory(),
+          EntityTestFactory.createInewsStory(),
+          EntityTestFactory.createInewsStory(),
+        ]
+        const cachedStories: Readonly<Record<string, InewsStory>> = {
+          [storyMetadataSequence[0].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[0]),
+          [storyMetadataSequence[2].id]: EntityTestFactory.createInewsStory(storyMetadataSequence[2]),
+          [deletedStories[0].id]: deletedStories[0],
+          [deletedStories[1].id]: deletedStories[1],
+          [deletedStories[2].id]: deletedStories[2],
+        }
+        const testee: InewsQueueDifferImplementation = createTestee()
+
+        const result: readonly string[] = testee.getDeletedStoryIds(storyMetadataSequence, cachedStories)
+
+        expect(result).toMatchObject(deletedStories.map(story => story.id))
+      })
+    })
+  })
+})
+
+function createTestee(): InewsQueueDifferImplementation {
+  return new InewsQueueDifferImplementation()
+}

--- a/src/business-logic/services/inews-queue-differ-implementation.spec.ts
+++ b/src/business-logic/services/inews-queue-differ-implementation.spec.ts
@@ -5,21 +5,23 @@ import { EntityTestFactory } from '../factories/entity-test-factory'
 
 describe(InewsQueueDifferImplementation.name, () => {
   describe(InewsQueueDifferImplementation.prototype.getMetadataForUncachedStories, () => {
-    describe('when all stories are cached', () => it('returns an empty array', () => {
-      const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata] = [
-        EntityTestFactory.createInewsStoryMetadata(),
-        EntityTestFactory.createInewsStoryMetadata(),
-      ]
-      const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
-        [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory(storyMetadataSequence[0])],
-        [storyMetadataSequence[1].id, EntityTestFactory.createInewsStory(storyMetadataSequence[1])],
-      ])
-      const testee: InewsQueueDifferImplementation = createTestee()
+    describe('when all stories are cached', () => {
+      it('returns an empty array', () => {
+        const storyMetadataSequence: readonly [InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+          [storyMetadataSequence[0].id, EntityTestFactory.createInewsStory(storyMetadataSequence[0])],
+          [storyMetadataSequence[1].id, EntityTestFactory.createInewsStory(storyMetadataSequence[1])],
+        ])
+        const testee: InewsQueueDifferImplementation = createTestee()
 
-      const result: readonly InewsStoryMetadata[] = testee.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
+        const result: readonly InewsStoryMetadata[] = testee.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
 
-      expect(result).toMatchObject([])
-    }))
+        expect(result).toMatchObject([])
+      })
+    })
 
     describe('when some stories are uncached', () => {
       it('returns metadata for the uncached stories', () => {

--- a/src/business-logic/services/inews-queue-differ-implementation.ts
+++ b/src/business-logic/services/inews-queue-differ-implementation.ts
@@ -1,0 +1,53 @@
+import { InewsStory } from '../entities/inews-story'
+import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
+import { InewsQueueDiffer } from '../interfaces/inews-queue-differ'
+
+export class InewsQueueDifferImplementation implements InewsQueueDiffer {
+  public getMetadataForUncachedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[] {
+    return storyMetadataSequence
+      .filter(storyMetadata => !this.isStoryCached(storyMetadata.id, cachedStories))
+  }
+
+  private isStoryCached(storyId: string, cachedStories: Readonly<Record<string, InewsStory>>): boolean {
+    return storyId in cachedStories
+  }
+
+  public getMetadataForStoriesWithChangedContent(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[] {
+    return storyMetadataSequence
+      .filter(storyMetadata => this.hasStoryContentChanged(storyMetadata, cachedStories))
+  }
+
+  private hasStoryContentChanged(storyMetadata: InewsStoryMetadata, cachedStories: Readonly<Record<string, InewsStory>>): boolean {
+    const cachedStory: InewsStory | undefined = cachedStories[storyMetadata.id]
+    if (!cachedStory) {
+      return false
+    }
+
+    return storyMetadata.contentLocator !== cachedStory.contentLocator
+  }
+
+  public getMetadataForMovedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[] {
+    return storyMetadataSequence
+      .filter(storyMetadata => this.isStoryMoved(storyMetadata, cachedStories))
+  }
+
+  private isStoryMoved(storyMetadata: InewsStoryMetadata, cachedStories: Readonly<Record<string, InewsStory>>): boolean {
+    const cachedStory: InewsStory | undefined = cachedStories[storyMetadata.id]
+    if (!cachedStory) {
+      return false
+    }
+
+    if (storyMetadata.versionLocator === cachedStory.versionLocator) {
+      return false
+    }
+
+    return storyMetadata.contentLocator === cachedStory.contentLocator
+  }
+
+  public getDeletedStoryIds(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly string[] {
+    const currentStoryIds: ReadonlySet<string> = new Set(storyMetadataSequence.map(storyMetadata => storyMetadata.id))
+    return Object.values(cachedStories)
+      .filter(story => !currentStoryIds.has(story.id))
+      .map(story => story.id)
+  }
+}

--- a/src/business-logic/services/inews-queue-differ-implementation.ts
+++ b/src/business-logic/services/inews-queue-differ-implementation.ts
@@ -3,22 +3,22 @@ import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
 import { InewsQueueDiffer } from '../interfaces/inews-queue-differ'
 
 export class InewsQueueDifferImplementation implements InewsQueueDiffer {
-  public getMetadataForUncachedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[] {
+  public getMetadataForUncachedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[] {
     return storyMetadataSequence
       .filter(storyMetadata => !this.isStoryCached(storyMetadata.id, cachedStories))
   }
 
-  private isStoryCached(storyId: string, cachedStories: Readonly<Record<string, InewsStory>>): boolean {
-    return storyId in cachedStories
+  private isStoryCached(storyId: string, cachedStories: ReadonlyMap<string, InewsStory>): boolean {
+    return cachedStories.has(storyId)
   }
 
-  public getMetadataForStoriesWithChangedContent(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[] {
+  public getMetadataForStoriesWithChangedContent(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[] {
     return storyMetadataSequence
       .filter(storyMetadata => this.hasStoryContentChanged(storyMetadata, cachedStories))
   }
 
-  private hasStoryContentChanged(storyMetadata: InewsStoryMetadata, cachedStories: Readonly<Record<string, InewsStory>>): boolean {
-    const cachedStory: InewsStory | undefined = cachedStories[storyMetadata.id]
+  private hasStoryContentChanged(storyMetadata: InewsStoryMetadata, cachedStories: ReadonlyMap<string, InewsStory>): boolean {
+    const cachedStory: InewsStory | undefined = cachedStories.get(storyMetadata.id)
     if (!cachedStory) {
       return false
     }
@@ -26,13 +26,13 @@ export class InewsQueueDifferImplementation implements InewsQueueDiffer {
     return storyMetadata.contentLocator !== cachedStory.contentLocator
   }
 
-  public getMetadataForMovedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly InewsStoryMetadata[] {
+  public getMetadataForMovedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[] {
     return storyMetadataSequence
       .filter(storyMetadata => this.isStoryMoved(storyMetadata, cachedStories))
   }
 
-  private isStoryMoved(storyMetadata: InewsStoryMetadata, cachedStories: Readonly<Record<string, InewsStory>>): boolean {
-    const cachedStory: InewsStory | undefined = cachedStories[storyMetadata.id]
+  private isStoryMoved(storyMetadata: InewsStoryMetadata, cachedStories: ReadonlyMap<string, InewsStory>): boolean {
+    const cachedStory: InewsStory | undefined = cachedStories.get(storyMetadata.id)
     if (!cachedStory) {
       return false
     }
@@ -44,10 +44,9 @@ export class InewsQueueDifferImplementation implements InewsQueueDiffer {
     return storyMetadata.contentLocator === cachedStory.contentLocator
   }
 
-  public getDeletedStoryIds(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: Readonly<Record<string, InewsStory>>): readonly string[] {
+  public getDeletedStoryIds(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly string[] {
     const currentStoryIds: ReadonlySet<string> = new Set(storyMetadataSequence.map(storyMetadata => storyMetadata.id))
-    return Object.values(cachedStories)
-      .filter(story => !currentStoryIds.has(story.id))
-      .map(story => story.id)
+    return Array.from(cachedStories.keys())
+      .filter(storyId => !currentStoryIds.has(storyId))
   }
 }

--- a/src/business-logic/services/inews-queue-differ-implementation.ts
+++ b/src/business-logic/services/inews-queue-differ-implementation.ts
@@ -4,8 +4,7 @@ import { InewsQueueDiffer } from '../interfaces/inews-queue-differ'
 
 export class InewsQueueDifferImplementation implements InewsQueueDiffer {
   public getMetadataForUncachedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[] {
-    return storyMetadataSequence
-      .filter(storyMetadata => !this.isStoryCached(storyMetadata.id, cachedStories))
+    return storyMetadataSequence.filter(storyMetadata => !this.isStoryCached(storyMetadata.id, cachedStories))
   }
 
   private isStoryCached(storyId: string, cachedStories: ReadonlyMap<string, InewsStory>): boolean {
@@ -13,8 +12,7 @@ export class InewsQueueDifferImplementation implements InewsQueueDiffer {
   }
 
   public getMetadataForStoriesWithChangedContent(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[] {
-    return storyMetadataSequence
-      .filter(storyMetadata => this.hasStoryContentChanged(storyMetadata, cachedStories))
+    return storyMetadataSequence.filter(storyMetadata => this.hasStoryContentChanged(storyMetadata, cachedStories))
   }
 
   private hasStoryContentChanged(storyMetadata: InewsStoryMetadata, cachedStories: ReadonlyMap<string, InewsStory>): boolean {
@@ -27,8 +25,7 @@ export class InewsQueueDifferImplementation implements InewsQueueDiffer {
   }
 
   public getMetadataForMovedStories(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly InewsStoryMetadata[] {
-    return storyMetadataSequence
-      .filter(storyMetadata => this.isStoryMoved(storyMetadata, cachedStories))
+    return storyMetadataSequence.filter(storyMetadata => this.isStoryMoved(storyMetadata, cachedStories))
   }
 
   private isStoryMoved(storyMetadata: InewsStoryMetadata, cachedStories: ReadonlyMap<string, InewsStory>): boolean {
@@ -46,7 +43,6 @@ export class InewsQueueDifferImplementation implements InewsQueueDiffer {
 
   public getDeletedStoryIds(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly string[] {
     const currentStoryIds: ReadonlySet<string> = new Set(storyMetadataSequence.map(storyMetadata => storyMetadata.id))
-    return Array.from(cachedStories.keys())
-      .filter(storyId => !currentStoryIds.has(storyId))
+    return Array.from(cachedStories.keys()).filter(storyId => !currentStoryIds.has(storyId))
   }
 }

--- a/src/business-logic/services/inews-story-rank-resolver-implementation.spec.ts
+++ b/src/business-logic/services/inews-story-rank-resolver-implementation.spec.ts
@@ -1,0 +1,236 @@
+import { InewsStoryRankResolverImplementation } from './inews-story-rank-resolver-implementation'
+import { InewsStoryRankResolver } from '../interfaces/inews-story-rank-resolver'
+import { EntityTestFactory } from '../factories/entity-test-factory'
+import { InewsStory } from '../entities/inews-story'
+import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
+
+describe(InewsStoryRankResolverImplementation.name, () => {
+  describe(InewsStoryRankResolverImplementation.prototype.getInewsStoryRanks.name, () => {
+    describe('when no stories are cached', () => {
+      it('assigns ranks linear', () => {
+        const testee: InewsStoryRankResolver = createTestee()
+        const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+          EntityTestFactory.createInewsStoryMetadata(),
+        ]
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map()
+
+        const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+        expect(Array.from(result.entries())).toMatchObject([
+          [inewsStoryIdSequence[0].id, 1000],
+          [inewsStoryIdSequence[1].id, 2000],
+          [inewsStoryIdSequence[2].id, 3000],
+        ])
+      })
+    })
+
+    describe('when some stories are cached', () => {
+      describe('when the uncached stories are in between cached stories', () => {
+        it('fits in the uncached stories in between the cached stories', () => {
+          const testee: InewsStoryRankResolver = createTestee()
+          const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+          ]
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [inewsStoryIdSequence[0].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[0], rank: 2000 })],
+            [inewsStoryIdSequence[4].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[4], rank: 4000 })],
+          ])
+
+          const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+          expect(Array.from(result.entries())).toMatchObject([
+            [inewsStoryIdSequence[0].id, 2000],
+            [inewsStoryIdSequence[1].id, 3000],
+            [inewsStoryIdSequence[2].id, 3500],
+            [inewsStoryIdSequence[3].id, 3750],
+            [inewsStoryIdSequence[4].id, 4000],
+          ])
+        })
+      })
+
+      describe('when the uncached stories are at the start of the story sequence', () => {
+        it('fits the uncached stories in between rank 0 and the rank of the first cached story', () => {
+          const testee: InewsStoryRankResolver = createTestee()
+          const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+          ]
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [inewsStoryIdSequence[3].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[3], rank: 2000 })],
+            [inewsStoryIdSequence[4].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[4], rank: 6000 })],
+          ])
+
+          const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+          expect(Array.from(result.entries())).toMatchObject([
+            [inewsStoryIdSequence[0].id, 1000],
+            [inewsStoryIdSequence[1].id, 1500],
+            [inewsStoryIdSequence[2].id, 1750],
+            [inewsStoryIdSequence[3].id, 2000],
+            [inewsStoryIdSequence[4].id, 6000],
+          ])
+        })
+      })
+
+      describe('when the uncached stories are at the end of the story sequence', () => {
+        it('the uncached stories are assigned ranks linearly increasing from the rank of the highest ranked cached story', () => {
+          const testee: InewsStoryRankResolver = createTestee()
+          const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+          ]
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [inewsStoryIdSequence[0].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[0], rank: 2000 })],
+            [inewsStoryIdSequence[1].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[1], rank: 6000 })],
+          ])
+
+          const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+          expect(Array.from(result.entries())).toMatchObject([
+            [inewsStoryIdSequence[0].id, 2000],
+            [inewsStoryIdSequence[1].id, 6000],
+            [inewsStoryIdSequence[2].id, 7000],
+            [inewsStoryIdSequence[3].id, 8000],
+            [inewsStoryIdSequence[4].id, 9000],
+          ])
+        })
+      })
+
+      describe('when the highest ranked cached stories is moved into the middle of story sequence', () => {
+        it('the highest ranked story is given a new rank in between the ranks of the stories that it was placed in between', () => {
+          const testee: InewsStoryRankResolver = createTestee()
+          const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+          ]
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [inewsStoryIdSequence[0].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[0], rank: 1000 })],
+            [inewsStoryIdSequence[1].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[1], rank: 2000 })],
+            [inewsStoryIdSequence[2].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[2], rank: 5000, versionLocator: 'newVersion' })],
+            [inewsStoryIdSequence[3].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[3], rank: 3000 })],
+            [inewsStoryIdSequence[4].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[4], rank: 4000 })],
+          ])
+
+          const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+          expect(Array.from(result.entries())).toMatchObject([
+            [inewsStoryIdSequence[0].id, 1000],
+            [inewsStoryIdSequence[1].id, 2000],
+            [inewsStoryIdSequence[2].id, 2500],
+            [inewsStoryIdSequence[3].id, 3000],
+            [inewsStoryIdSequence[4].id, 4000],
+          ])
+        })
+      })
+
+      describe('when multiple high-ranked stories are moved into the middle of the story sequence', () => {
+        it('fits the high-ranked stories ranks in between the surround stories ranks', () => {
+          const testee: InewsStoryRankResolver = createTestee()
+          const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+          ]
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [inewsStoryIdSequence[0].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[0], rank: 1000 })],
+            [inewsStoryIdSequence[1].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[1], rank: 4000, versionLocator: 'newVersion' })],
+            [inewsStoryIdSequence[2].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[2], rank: 5000, versionLocator: 'newVersion' })],
+            [inewsStoryIdSequence[3].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[3], rank: 2000 })],
+            [inewsStoryIdSequence[4].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[4], rank: 3000 })],
+          ])
+
+          const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+          expect(Array.from(result.entries())).toMatchObject([
+            [inewsStoryIdSequence[0].id, 1000],
+            [inewsStoryIdSequence[1].id, 1500],
+            [inewsStoryIdSequence[2].id, 1750],
+            [inewsStoryIdSequence[3].id, 2000],
+            [inewsStoryIdSequence[4].id, 3000],
+          ])
+        })
+      })
+
+      describe('when the lowest ranked cached stories is moved into the middle of story sequence', () => {
+        it('the lowest ranked story is given a new rank in between the ranks of the stories that it was placed in between', () => {
+          const testee: InewsStoryRankResolver = createTestee()
+          const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+          ]
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [inewsStoryIdSequence[0].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[0], rank: 2000 })],
+            [inewsStoryIdSequence[1].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[1], rank: 3000 })],
+            [inewsStoryIdSequence[2].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[2], rank: 1000, versionLocator: 'newVersion' })],
+            [inewsStoryIdSequence[3].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[3], rank: 4000 })],
+            [inewsStoryIdSequence[4].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[4], rank: 5000 })],
+          ])
+
+          const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+          expect(Array.from(result.entries())).toMatchObject([
+            [inewsStoryIdSequence[0].id, 2000],
+            [inewsStoryIdSequence[1].id, 3000],
+            [inewsStoryIdSequence[2].id, 3500],
+            [inewsStoryIdSequence[3].id, 4000],
+            [inewsStoryIdSequence[4].id, 5000],
+          ])
+        })
+      })
+
+      describe('when multiple low-ranked stories are moved into the middle of the story sequence', () => {
+        it('fits the low-ranked stories ranks in between the surround stories ranks', () => {
+          const testee: InewsStoryRankResolver = createTestee()
+          const inewsStoryIdSequence: readonly [InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata, InewsStoryMetadata] = [
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+            EntityTestFactory.createInewsStoryMetadata(),
+          ]
+          const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+            [inewsStoryIdSequence[0].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[0], rank: 3000 })],
+            [inewsStoryIdSequence[1].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[1], rank: 1000, versionLocator: 'newVersion' })],
+            [inewsStoryIdSequence[2].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[2], rank: 2000, versionLocator: 'newVersion' })],
+            [inewsStoryIdSequence[3].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[3], rank: 4000 })],
+            [inewsStoryIdSequence[4].id, EntityTestFactory.createInewsStory({ ...inewsStoryIdSequence[4], rank: 5000 })],
+          ])
+
+          const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryIdSequence, cachedStories)
+
+          expect(Array.from(result.entries())).toMatchObject([
+            [inewsStoryIdSequence[0].id, 3000],
+            [inewsStoryIdSequence[1].id, 3500],
+            [inewsStoryIdSequence[2].id, 3750],
+            [inewsStoryIdSequence[3].id, 4000],
+            [inewsStoryIdSequence[4].id, 5000],
+          ])
+        })
+      })
+    })
+  })
+})
+
+function createTestee(): InewsStoryRankResolver {
+  return new InewsStoryRankResolverImplementation()
+}

--- a/src/business-logic/services/inews-story-rank-resolver-implementation.ts
+++ b/src/business-logic/services/inews-story-rank-resolver-implementation.ts
@@ -7,10 +7,7 @@ export type RankEntry = readonly [string, number]
 const RANK_STEP_SIZE: number = 1000
 
 export class InewsStoryRankResolverImplementation implements InewsStoryRankResolver {
-  public getInewsStoryRanks(
-    storyIds: readonly InewsStoryMetadata[],
-    cachedStories: ReadonlyMap<string, InewsStory>,
-  ): ReadonlyMap<string, number> {
+  public getInewsStoryRanks(storyIds: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): ReadonlyMap<string, number> {
     return new Map(this.getCachedRanks(storyIds, cachedStories).reduce(this.updateRankReducer.bind(this), []))
   }
 
@@ -27,24 +24,14 @@ export class InewsStoryRankResolverImplementation implements InewsStoryRankResol
     return cachedInewsStory.rank
   }
 
-  private updateRankReducer(
-    updatedRanks: readonly RankEntry[],
-    [storyId, cachedRank]: RankEntry,
-    index: number,
-    cachedRanks: readonly RankEntry[],
-  ): readonly RankEntry[] {
+  private updateRankReducer(updatedRanks: readonly RankEntry[], [storyId, cachedRank]: RankEntry, index: number, cachedRanks: readonly RankEntry[]): readonly RankEntry[] {
     return [
       ...updatedRanks,
       [storyId, this.getUpdatedRank(cachedRank, index, updatedRanks, cachedRanks)],
     ]
   }
 
-  private getUpdatedRank(
-    cachedRank: number,
-    index: number,
-    updatedRanks: readonly RankEntry[],
-    cachedRanks: readonly RankEntry[],
-  ): number {
+  private getUpdatedRank(cachedRank: number, index: number, updatedRanks: readonly RankEntry[], cachedRanks: readonly RankEntry[]): number {
     const previousRank: number = updatedRanks[index - 1]?.[1] ?? 0
     const nextRank: number | undefined = this.getNextRankLargerThanPreviousRank(cachedRanks, index, previousRank)
 

--- a/src/business-logic/services/inews-story-rank-resolver-implementation.ts
+++ b/src/business-logic/services/inews-story-rank-resolver-implementation.ts
@@ -1,0 +1,72 @@
+import { InewsStory } from '../entities/inews-story'
+import { InewsStoryRankResolver } from '../interfaces/inews-story-rank-resolver'
+import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
+
+export type RankEntry = readonly [string, number]
+
+const RANK_STEP_SIZE: number = 1000
+
+export class InewsStoryRankResolverImplementation implements InewsStoryRankResolver {
+  public getInewsStoryRanks(
+    storyIds: readonly InewsStoryMetadata[],
+    cachedStories: ReadonlyMap<string, InewsStory>,
+  ): ReadonlyMap<string, number> {
+    return new Map(this.getCachedRanks(storyIds, cachedStories).reduce(this.updateRankReducer.bind(this), []))
+  }
+
+  private getCachedRanks(inewsStoryMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): readonly RankEntry[] {
+    return inewsStoryMetadataSequence.map(inewsStoryMetadata => [inewsStoryMetadata.id, this.getCachedRank(inewsStoryMetadata, cachedStories)])
+  }
+
+  private getCachedRank(inewsStoryMetadata: InewsStoryMetadata, cachedStories: ReadonlyMap<string, InewsStory>): number {
+    const storyId: string = inewsStoryMetadata.id
+    const cachedInewsStory: InewsStory | undefined = cachedStories.get(storyId)
+    if (!cachedInewsStory || cachedInewsStory.versionLocator !== inewsStoryMetadata.versionLocator) {
+      return 0
+    }
+    return cachedInewsStory.rank
+  }
+
+  private updateRankReducer(
+    updatedRanks: readonly RankEntry[],
+    [storyId, cachedRank]: RankEntry,
+    index: number,
+    cachedRanks: readonly RankEntry[],
+  ): readonly RankEntry[] {
+    return [
+      ...updatedRanks,
+      [storyId, this.getUpdatedRank(cachedRank, index, updatedRanks, cachedRanks)],
+    ]
+  }
+
+  private getUpdatedRank(
+    cachedRank: number,
+    index: number,
+    updatedRanks: readonly RankEntry[],
+    cachedRanks: readonly RankEntry[],
+  ): number {
+    const previousRank: number = updatedRanks[index - 1]?.[1] ?? 0
+    const nextRank: number | undefined = this.getNextRankLargerThanPreviousRank(cachedRanks, index, previousRank)
+
+    if (cachedRank <= previousRank) {
+      return this.getRankInBetween(previousRank, nextRank)
+    }
+
+    if (nextRank && cachedRank >= nextRank) {
+      return this.getRankInBetween(previousRank, nextRank)
+    }
+
+    return cachedRank
+  }
+
+  private getNextRankLargerThanPreviousRank(cachedRanks: readonly RankEntry[], index: number, previousRank: number): number | undefined {
+    return cachedRanks
+      .slice(index + 1)
+      .find(([, cachedNextRank]) => cachedNextRank > previousRank)?.[1]
+  }
+
+  private getRankInBetween(previousRank: number, maybeNextRank?: number): number {
+    const nextRank = maybeNextRank ?? previousRank + 2 * RANK_STEP_SIZE
+    return previousRank + (nextRank - previousRank) / 2
+  }
+}

--- a/src/business-logic/services/inews-story-rank-resolver-implementation.ts
+++ b/src/business-logic/services/inews-story-rank-resolver-implementation.ts
@@ -2,7 +2,7 @@ import { InewsStory } from '../entities/inews-story'
 import { InewsStoryRankResolver } from '../interfaces/inews-story-rank-resolver'
 import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
 
-export type RankEntry = readonly [string, number]
+type RankEntry = readonly [string, number]
 
 const RANK_STEP_SIZE: number = 1000
 

--- a/src/business-logic/services/nsml-inews-story-parser.spec.ts
+++ b/src/business-logic/services/nsml-inews-story-parser.spec.ts
@@ -35,6 +35,7 @@ describe(NsmlInewsStoryParser.name, () => {
           contentLocator: inewsId.contentLocator,
           versionLocator: inewsId.versionLocator,
           metadata: {},
+          rank: 0,
           cues: [
             {
               type: CueType.CONTENT,

--- a/src/business-logic/services/nsml-inews-story-parser.spec.ts
+++ b/src/business-logic/services/nsml-inews-story-parser.spec.ts
@@ -2,16 +2,20 @@ import { NsmlInewsStoryParser } from './nsml-inews-story-parser'
 import { InewsStoryParser } from '../interfaces/inews-story-parser'
 import { RegExpNsmlParser } from './reg-exp-nsml-parser'
 import { CueType, InewsCue, InewsStory } from '../entities/inews-story'
+import { InewsId } from '../entities/inews-id'
+import { EntityTestFactory } from '../factories/entity-test-factory'
 import { InewsIdParserImplementation } from './inews-id-parser-implementation'
 
 describe(NsmlInewsStoryParser.name, () => {
   describe(NsmlInewsStoryParser.prototype.parseInewsStory.name, () => {
     describe('when fields with non-alphanumeric ids are present', () => {
       it('converts the field ids to camelCase', () => {
-        const text: string = '<nsml version="some version 1.0"><head><storyid>001ea938:00ff8cf0:656994ba</storyid></head><story><fields><f id=title></f><f id=my-weird-key-name>some value</f></fields></story>'
+        const storyId: string = '001ea938'
+        const text: string = `<nsml version="some version 1.0"><head><storyid>${storyId}:00ff8cf0:656994ba</storyid></head><story><fields><f id=title></f><f id=my-weird-key-name>some value</f></fields></story>`
+        const inewsId: InewsId = EntityTestFactory.createInewsId({ storyId })
         const testee: InewsStoryParser = createTestee()
 
-        const result: InewsStory = testee.parseInewsStory(text, 'queue-id')
+        const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
 
         expect(result.metadata).toHaveProperty('myWeirdKeyName')
         expect(result.metadata.myWeirdKeyName).toEqual('some value')
@@ -20,14 +24,16 @@ describe(NsmlInewsStoryParser.name, () => {
 
     describe('when story has anchored element references and text paragraphs', () => {
       it('merges anchored elements into the body paragraph order as cues', () => {
-        const text: string = '<nsml version="some version 1.0"><head><storyid>001ea938:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p><p><a idref=1></p></body><aeset><ae id=0><ap>Line1</ap><ap>Line2</ap></ae><ae id=1><ap>Line3</ap><ap>Line4</ap></ae></aeset></aeset></story>'
+        const storyId: string = '001ea938'
+        const text: string = `<nsml version="some version 1.0"><head><storyid>${storyId}:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p><p><a idref=1></p></body><aeset><ae id=0><ap>Line1</ap><ap>Line2</ap></ae><ae id=1><ap>Line3</ap><ap>Line4</ap></ae></aeset></aeset></story>`
+        const inewsId: InewsId = EntityTestFactory.createInewsId({ storyId })
         const testee: InewsStoryParser = createTestee()
         const expectedInewsStory: InewsStory = {
           id: '001EA938',
           name: 'Segment title',
           queueId: 'queue-id',
-          contentLocator: '00FF8CF0',
-          versionLocator: '656994BA',
+          contentLocator: inewsId.contentLocator,
+          versionLocator: inewsId.versionLocator,
           metadata: {},
           cues: [
             {
@@ -45,7 +51,7 @@ describe(NsmlInewsStoryParser.name, () => {
           ],
         }
 
-        const result: InewsStory = testee.parseInewsStory(text, 'queue-id')
+        const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
 
         expect(result).toMatchObject(expectedInewsStory)
       })
@@ -53,7 +59,9 @@ describe(NsmlInewsStoryParser.name, () => {
 
     describe('when story has no anchored elements but have anchored element references', () => {
       it('ignores the anchored element references', () => {
-        const text: string = '<nsml version="some version 1.0"><head><storyid>001ea938:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p></body></story>'
+        const storyId: string = '001ea938'
+        const text: string = `<nsml version="some version 1.0"><head><storyid>${storyId}:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p></body></story>`
+        const inewsId: InewsId = EntityTestFactory.createInewsId({ storyId })
         const testee: InewsStoryParser = createTestee()
         const expectedCues: InewsCue[] = [
           {
@@ -62,10 +70,78 @@ describe(NsmlInewsStoryParser.name, () => {
           },
         ]
 
-        const result: InewsStory = testee.parseInewsStory(text, 'queue-id')
+        const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
 
         expect(result.cues).toMatchObject(expectedCues)
       })
+    })
+  })
+
+  describe('when story id from inews id differs from the story id in the NSML document', () => {
+    it('throws an error', () => {
+      const text: string = '<nsml version="some version 1.0"><head><storyid>11223344:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p></body></story>'
+      const storyId: string = '001ea938'
+      const inewsId: InewsId = EntityTestFactory.createInewsId({ storyId })
+      const testee: InewsStoryParser = createTestee()
+
+      const result: () => InewsStory = () => testee.parseInewsStory(text, 'queue-id', inewsId)
+
+      expect(result).toThrow()
+    })
+
+    describe('when the only difference is character casing', () => {
+      it('uses an uppercased version of the story id', () => {
+        const storyId: string = '001EA938'
+        const text: string = `<nsml version="some version 1.0"><head><storyid>${storyId.toLowerCase()}:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p></body></story>`
+        const inewsId: InewsId = EntityTestFactory.createInewsId({ storyId })
+        const testee: InewsStoryParser = createTestee()
+
+        const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
+
+        expect(result.id).toBe(storyId)
+      })
+    })
+  })
+
+  describe('when the locators given differs from the ones in the NSML document', () => {
+    it('uses the given locators', () => {
+      const inewsId: InewsId = EntityTestFactory.createInewsId({ storyId: '1234ABCD', contentLocator: '11111111', versionLocator: '22222222' })
+      const text: string = `<nsml version="some version 1.0"><head><storyid>${inewsId.storyId}:00000000:00000000</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p></body></story>`
+      const testee: InewsStoryParser = createTestee()
+
+      const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
+
+      expect(result.contentLocator).toBe(inewsId.contentLocator)
+      expect(result.versionLocator).toBe(inewsId.versionLocator)
+    })
+  })
+
+  describe('when story has non-fully uppercased story id and locators', () => {
+    it('uppercases the story id', () => {
+      const storyId: string = '001ea938'
+      const text: string = `<nsml version="some version 1.0"><head><storyid>${storyId}:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p><p><a idref=1></p></body><aeset><ae id=0><ap>Line1</ap><ap>Line2</ap></ae><ae id=1><ap>Line3</ap><ap>Line4</ap></ae></aeset></aeset></story>`
+      const inewsId: InewsId = EntityTestFactory.createInewsId({ storyId })
+      const testee: InewsStoryParser = createTestee()
+
+      const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
+
+      expect(result.id).toBe('001EA938')
+    })
+
+    it('uppercases the story locators', () => {
+      const storyId: string = '001ea938'
+      const text: string = `<nsml version="some version 1.0"><head><storyid>${storyId}:00ff8cf0:656994ba</storyid></head><story><fields><f id=title>Segment title</f></fields></fields><body><p><pi>KAM 1</pi></p><p><a idref=0></p><p><a idref=1></p></body><aeset><ae id=0><ap>Line1</ap><ap>Line2</ap></ae><ae id=1><ap>Line3</ap><ap>Line4</ap></ae></aeset></aeset></story>`
+      const inewsId: InewsId = EntityTestFactory.createInewsId({
+        storyId,
+        contentLocator: '11aabbcc',
+        versionLocator: '22ddeeff',
+      })
+      const testee: InewsStoryParser = createTestee()
+
+      const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
+
+      expect(result.contentLocator).toBe('11AABBCC')
+      expect(result.versionLocator).toBe('22DDEEFF')
     })
   })
 })

--- a/src/business-logic/services/nsml-inews-story-parser.ts
+++ b/src/business-logic/services/nsml-inews-story-parser.ts
@@ -23,6 +23,7 @@ export class NsmlInewsStoryParser implements InewsStoryParser {
       versionLocator: inewsId.versionLocator.toUpperCase(),
       metadata: this.formatMetadata(nsmlDocument.fields),
       cues: this.mergeIntoCues(nsmlDocument.body, nsmlDocument.anchoredElements),
+      rank: 0,
     }
   }
 

--- a/src/business-logic/services/nsml-inews-story-parser.ts
+++ b/src/business-logic/services/nsml-inews-story-parser.ts
@@ -2,8 +2,8 @@ import { InewsStoryParser } from '../interfaces/inews-story-parser'
 import { CueType, InewsCue, InewsStory } from '../entities/inews-story'
 import { NsmlAnchoredElement, NsmlDocument, NsmlParagraph, NsmlParagraphType } from '../value-objects/nsml-document'
 import { NsmlParser } from '../interfaces/nsml-parser'
-import { InewsIdParser } from '../interfaces/inews-id-parser'
 import { InewsId } from '../entities/inews-id'
+import { InewsIdParser } from '../interfaces/inews-id-parser'
 
 export class NsmlInewsStoryParser implements InewsStoryParser {
   public constructor(
@@ -11,17 +11,24 @@ export class NsmlInewsStoryParser implements InewsStoryParser {
     private readonly inewsIdParser: InewsIdParser,
   ) {}
 
-  public parseInewsStory(text: string, queueId: string): InewsStory {
+  public parseInewsStory(text: string, queueId: string, inewsId: InewsId): InewsStory {
     const nsmlDocument: NsmlDocument = this.nsmlParser.parseNsmlDocument(text)
-    const inewsId: InewsId = this.inewsIdParser.parseInewsId(nsmlDocument.head.storyid)
+    const parsedInewsId: InewsId = this.inewsIdParser.parseInewsId(nsmlDocument.head.storyid)
+    this.assertStoryIdConsistency(inewsId, parsedInewsId)
     return {
-      id: inewsId.storyId,
+      id: nsmlDocument.head.storyid.split(':')[0]!.toUpperCase(),
       name: nsmlDocument.fields.title,
       queueId,
       contentLocator: inewsId.contentLocator,
       versionLocator: inewsId.versionLocator,
       metadata: this.formatMetadata(nsmlDocument.fields),
       cues: this.mergeIntoCues(nsmlDocument.body, nsmlDocument.anchoredElements),
+    }
+  }
+
+  private assertStoryIdConsistency(inewsId: InewsId, parsedInewsId: InewsId): void {
+    if (inewsId.storyId !== parsedInewsId.storyId) {
+      throw new Error(`The given story id '${inewsId.storyId}' should match the parsed story id '${parsedInewsId.storyId}'.`)
     }
   }
 

--- a/src/business-logic/services/nsml-inews-story-parser.ts
+++ b/src/business-logic/services/nsml-inews-story-parser.ts
@@ -16,11 +16,11 @@ export class NsmlInewsStoryParser implements InewsStoryParser {
     const parsedInewsId: InewsId = this.inewsIdParser.parseInewsId(nsmlDocument.head.storyid)
     this.assertStoryIdConsistency(inewsId, parsedInewsId)
     return {
-      id: nsmlDocument.head.storyid.split(':')[0]!.toUpperCase(),
+      id: inewsId.storyId.toUpperCase(),
       name: nsmlDocument.fields.title,
       queueId,
-      contentLocator: inewsId.contentLocator,
-      versionLocator: inewsId.versionLocator,
+      contentLocator: inewsId.contentLocator.toUpperCase(),
+      versionLocator: inewsId.versionLocator.toUpperCase(),
       metadata: this.formatMetadata(nsmlDocument.fields),
       cues: this.mergeIntoCues(nsmlDocument.body, nsmlDocument.anchoredElements),
     }

--- a/src/business-logic/services/polling-inews-queue-watcher.ts
+++ b/src/business-logic/services/polling-inews-queue-watcher.ts
@@ -6,6 +6,7 @@ import { InewsQueuePoolObserver } from '../interfaces/inews-queue-pool-observer'
 import { InewsStory } from '../entities/inews-story'
 import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
 import { InewsQueueEmitter } from '../interfaces/inews-queue-emitter'
+import { InewsQueueDiffer } from '../interfaces/inews-queue-differ'
 
 export class PollingInewsQueueWatcher implements InewsQueueWatcher {
   private pollingTimer?: NodeJS.Timeout
@@ -18,6 +19,7 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
     private readonly connectionStateEmitter: ConnectionStateEmitter,
     private readonly inewsQueuePoolObserver: InewsQueuePoolObserver,
     private readonly inewsQueueEmitter: InewsQueueEmitter,
+    private readonly inewsQueueDiffer: InewsQueueDiffer,
     logger: Logger,
   ) {
     this.logger = logger.tag(this.constructor.name)
@@ -32,54 +34,82 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
 
   private schedulePolling(): void {
     this.clearPollingTimer()
-    this.pollData()
+    this.checkAndProcessQueues()
       .catch(error => this.logger.data(error).warn('Failed polling data.'))
       .finally(() => this.pollingTimer = setTimeout(() => this.schedulePolling(), this.pollingIntervalInMs))
   }
 
-  private async pollData(): Promise<void> {
-    const startTime: [number, number] = process.hrtime()
+  private async checkAndProcessQueues(): Promise<void> {
+    const startTime: bigint = process.hrtime.bigint()
     for (const queueId of this.queueIds) {
-      const changedStories: readonly InewsStory[] = await this.fetchChangedStoriesForQueue(queueId)
-      changedStories.forEach(story => this.inewsQueueEmitter.emitChangedInewsStory(story))
-      this.logger.debug(`${queueId} has ${changedStories.length} changed stories.`)
+      try {
+        await this.checkAndProcessQueue(queueId)
+      } catch (error) {
+        this.logger.data(error).error(`Failed getting updates for queue ${queueId}.`)
+      }
     }
-    const diff: [number, number] = process.hrtime(startTime)
-    this.logger.debug(`Pulling changes for ${this.queueIds.length} queues took ${diff[0] * 1000 + diff[1] / 1_000_000}ms.`)
+    const diff: bigint = process.hrtime.bigint() - startTime
+    this.logger.debug(`Pulling changes for ${this.queueIds.length} queues took ${Number(diff / 1_000_000n)}ms.`)
   }
 
-  private storyMetadataCache: Record<string, InewsStoryMetadata> = {}
+  private readonly storyCache: Record<string, InewsStory> = {}
 
-  private async fetchChangedStoriesForQueue(queueId: string): Promise<readonly InewsStory[]> {
-    const storyMetadataCollection: readonly InewsStoryMetadata[] = await this.inewsClient.getStoryMetadataForQueue(queueId)
-    let changedInewsStories: InewsStory[] = []
+  private async checkAndProcessQueue(queueId: string): Promise<void> {
+    const storyMetadataSequence: readonly InewsStoryMetadata[] = await this.getStoryMetadataSequence(queueId)
+
+    const metadataForNewStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForUncachedStories(storyMetadataSequence, this.storyCache)
+    const metadataForChangedStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForStoriesWithChangedContent(storyMetadataSequence, this.storyCache)
+    const metadataForMovedStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForMovedStories(storyMetadataSequence, this.storyCache)
+    const deletedStoryIds: readonly string[] = this.inewsQueueDiffer.getDeletedStoryIds(storyMetadataSequence, this.storyCache)
+
+    const newStories: readonly InewsStory[] = await this.getStories(queueId, metadataForNewStories)
+    const changedStories: readonly InewsStory[] = await this.getStories(queueId, metadataForChangedStories)
+    const movedStories: readonly InewsStory[] = metadataForMovedStories.map(storyMetadata => this.getMovedStory(storyMetadata))
+
+    // TODO: compute ranks (remember that changed stories can also have been moved).
+    deletedStoryIds.forEach(storyId => this.inewsQueueEmitter.emitDeletedInewsStory(queueId, storyId))
+    changedStories.forEach(story => this.inewsQueueEmitter.emitChangedInewsStory(story))
+    newStories.forEach(story => this.inewsQueueEmitter.emitCreatedInewsStory(story))
+    movedStories.forEach(story => this.inewsQueueEmitter.emitMovedInewsStory(story))
+
+    // TODO: Remove this log statement
+    if (deletedStoryIds.length > 0 || changedStories.length > 0 || newStories.length > 0 || movedStories.length > 0) {
+      this.logger.data({
+        newStoryIds: metadataForNewStories.map(storyMetadata => storyMetadata.id),
+        changedStoryIds: metadataForChangedStories.map(storyMetadata => storyMetadata.id),
+        movedStoryIds: metadataForMovedStories.map(storyMetadata => storyMetadata.id),
+        deletedStoryIds,
+      }).debug('Emitted events for:')
+    }
+
+    // TODO: Update cache through a repository
+    deletedStoryIds.forEach(storyId => delete this.storyCache[storyId])
+    newStories.concat(changedStories).concat(movedStories)
+      .forEach(story => this.storyCache[story.id] = story)
+  }
+
+  private getStoryMetadataSequence(queueId: string): Promise<readonly InewsStoryMetadata[]> {
+    return this.inewsClient.getStoryMetadataForQueue(queueId)
+  }
+
+  private async getStories(queueId: string, storyMetadataCollection: readonly InewsStoryMetadata[]): Promise<readonly InewsStory[]> {
+    let stories: InewsStory[] = []
     for (const storyMetadata of storyMetadataCollection) {
-      if (this.hasStoryContentChanged(storyMetadata)) {
-        changedInewsStories.push(await this.inewsClient.getStory(queueId, storyMetadata.id))
-      }
-      if (this.hasStoryChanged(storyMetadata)) {
-        this.storyMetadataCache[storyMetadata.id] = storyMetadata
-      }
+      stories.push(await this.inewsClient.getStory(queueId, { ...storyMetadata, storyId: storyMetadata.id }))
     }
-    return changedInewsStories
+    return stories
   }
 
-  private hasStoryContentChanged(storyMetadata: InewsStoryMetadata): boolean {
-    const previousStoryMetadata: InewsStoryMetadata | undefined = this.storyMetadataCache[storyMetadata.id]
-    if (!previousStoryMetadata) {
-      return true
+  private getMovedStory(storyMetadata: InewsStoryMetadata): InewsStory {
+    const cachedStory: InewsStory | undefined = this.storyCache[storyMetadata.id]
+    if (!cachedStory) {
+      throw new Error(`Uncached story with '${storyMetadata.id}' cannot be treated as a moved story.`)
     }
-
-    if (storyMetadata.versionLocator === previousStoryMetadata.versionLocator) {
-      return false
+    return {
+      ...cachedStory,
+      contentLocator: storyMetadata.contentLocator,
+      versionLocator: storyMetadata.versionLocator,
     }
-
-    return storyMetadata.contentLocator !== previousStoryMetadata.contentLocator
-  }
-
-  private hasStoryChanged(storyMetadata: InewsStoryMetadata): boolean {
-    const previousStoryMetadata: InewsStoryMetadata | undefined = this.storyMetadataCache[storyMetadata.id]
-    return storyMetadata.versionLocator !== previousStoryMetadata?.versionLocator
   }
 
   private clearPollingTimer(): void {

--- a/src/business-logic/services/polling-inews-queue-watcher.ts
+++ b/src/business-logic/services/polling-inews-queue-watcher.ts
@@ -49,7 +49,7 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
       }
     }
     const diff: bigint = process.hrtime.bigint() - startTime
-    this.logger.debug(`Pulling changes for ${this.queueIds.length} queues took ${Number(diff / 1_000_000n)}ms.`)
+    this.logger.debug(`Pulling changes for ${this.queueIds.length} queues took ${Number(diff) / 1_000_000}ms.`)
   }
 
   private readonly storyCache: Record<string, InewsStory> = {}


### PR DESCRIPTION
An InewsQueueDiffer is introduced and used by the PollingInewsQueueWatcher to classify changes, update state and emit the result. The PR also adds a InewsStoryRankResolver, which recomputes the rank for the stories that are touched (changed, created or moved).

The rank of stories that are touched are given ranks in between the rank of the surrounding non-touched stories with a base 2 logarithmic step size. If one or more touched stories are at the start, the same approach is used, where the surround ranks are 0 and the first untouched story. If the touched stories are placed after all untouched stories, then they are given a linearly increasing rank based on the last untouched story with a step size of 1000.

Note: Getting the full state of an iNews queue will be made in a separate PR.