### PR TITLE
SOF-1963: Improve rank resolver

### DIFF
--- a/src/business-logic/facades/service-facade.ts
+++ b/src/business-logic/facades/service-facade.ts
@@ -21,7 +21,7 @@ import { InewsIdParserImplementation } from '../services/inews-id-parser-impleme
 import { InewsQueueRepository } from '../interfaces/inews-queue-repository'
 import { InMemoryInewsQueueRepository } from '../services/in-memory-inews-queue-repository'
 import { InewsStoryRankResolver } from '../interfaces/inews-story-rank-resolver'
-import { LogarithmicInewsStoryRankResolver } from '../services/logarithmic-inews-story-rank-resolver'
+import { LinearInewsStoryRankResolver } from '../services/linear-inews-story-rank-resolver'
 
 export class ServiceFacade {
   private static inewsQueueRepository: InewsQueueRepository
@@ -72,6 +72,6 @@ export class ServiceFacade {
   }
 
   public static createInewsStoryRankResolver(): InewsStoryRankResolver {
-    return new LogarithmicInewsStoryRankResolver()
+    return new LinearInewsStoryRankResolver()
   }
 }

--- a/src/business-logic/services/linear-inews-story-rank-resolver.spec.ts
+++ b/src/business-logic/services/linear-inews-story-rank-resolver.spec.ts
@@ -1,11 +1,11 @@
-import { LogarithmicInewsStoryRankResolver } from './logarithmic-inews-story-rank-resolver'
+import { LinearInewsStoryRankResolver } from './linear-inews-story-rank-resolver'
 import { InewsStoryRankResolver } from '../interfaces/inews-story-rank-resolver'
 import { EntityTestFactory } from '../factories/entity-test-factory'
 import { InewsStory } from '../entities/inews-story'
 import { InewsStoryMetadata } from '../value-objects/inews-story-metadata'
 
-describe(LogarithmicInewsStoryRankResolver.name, () => {
-  describe(LogarithmicInewsStoryRankResolver.prototype.getInewsStoryRanks.name, () => {
+describe(LinearInewsStoryRankResolver.name, () => {
+  describe(LinearInewsStoryRankResolver.prototype.getInewsStoryRanks.name, () => {
     describe('when no stories are cached', () => {
       it('assigns every-increasing unique ranks matching the order of the given sequence', () => {
         const testee: InewsStoryRankResolver = createTestee()
@@ -258,7 +258,7 @@ describe(LogarithmicInewsStoryRankResolver.name, () => {
 })
 
 function createTestee(): InewsStoryRankResolver {
-  return new LogarithmicInewsStoryRankResolver()
+  return new LinearInewsStoryRankResolver()
 }
 
 function getRankSortedInewsStoryIds(inewsStoryMetadataSequence: readonly InewsStoryMetadata[], storyRankMap: ReadonlyMap<string, number>): readonly string[] {

--- a/src/business-logic/services/linear-inews-story-rank-resolver.ts
+++ b/src/business-logic/services/linear-inews-story-rank-resolver.ts
@@ -8,7 +8,7 @@ const RANK_STEP_SIZE: number = 1000
 const MINIMUM_MEAN_RANK_DISTANCE: number = 15
 const MAX_SAMPLE_SIZE: number = 40
 
-export class LogarithmicInewsStoryRankResolver implements InewsStoryRankResolver {
+export class LinearInewsStoryRankResolver implements InewsStoryRankResolver {
   public getInewsStoryRanks(inewsStoryMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): ReadonlyMap<string, number> {
     const inewsStoryRanks: readonly RankEntry[] = this.getInewsStoryRankEntries(inewsStoryMetadataSequence, cachedStories)
     const sampledMeanRankDistance: number = this.getSampledMeanRankDistance(inewsStoryRanks)

--- a/src/business-logic/services/logarithmic-inews-story-rank-resolver.spec.ts
+++ b/src/business-logic/services/logarithmic-inews-story-rank-resolver.spec.ts
@@ -230,6 +230,30 @@ describe(LogarithmicInewsStoryRankResolver.name, () => {
         expect(result.get(inewsStoryMetadataSequence[3].id)).toBe(14000)
       })
     })
+
+    describe('when the rank sequence have a high density', () => {
+      it('resolves the ranks for all stories as if it was the first resolution iteration', () => {
+        const testee: InewsStoryRankResolver = createTestee()
+        const inewsStoryMetadataSequence: readonly InewsStoryMetadata[] = [
+          EntityTestFactory.createInewsStoryMetadata({ id: 'story-a' }),
+          ...Array(100).fill(null).map((_, index) => EntityTestFactory.createInewsStoryMetadata({ id: `story-${index}` })),
+          EntityTestFactory.createInewsStoryMetadata({ id: 'story-b' }),
+          EntityTestFactory.createInewsStoryMetadata({ id: 'story-c' }),
+          EntityTestFactory.createInewsStoryMetadata({ id: 'story-d' }),
+        ]
+        const cachedStories: ReadonlyMap<string, InewsStory> = new Map([
+          [inewsStoryMetadataSequence[0]!.id, EntityTestFactory.createInewsStory({ ...inewsStoryMetadataSequence[0], rank: 100 })],
+          [inewsStoryMetadataSequence[101]!.id, EntityTestFactory.createInewsStory({ ...inewsStoryMetadataSequence[101], rank: 300 })],
+          [inewsStoryMetadataSequence[102]!.id, EntityTestFactory.createInewsStory({ ...inewsStoryMetadataSequence[102], rank: 400 })],
+          [inewsStoryMetadataSequence[103]!.id, EntityTestFactory.createInewsStory({ ...inewsStoryMetadataSequence[103], rank: 500 })],
+        ])
+
+        const resultWithoutCache: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryMetadataSequence, new Map())
+        const result: ReadonlyMap<string, number> = testee.getInewsStoryRanks(inewsStoryMetadataSequence, cachedStories)
+
+        result.forEach((rank, storyId) => expect([storyId, rank]).toMatchObject([storyId, resultWithoutCache.get(storyId)]))
+      })
+    })
   })
 })
 

--- a/src/business-logic/services/polling-inews-queue-watcher.ts
+++ b/src/business-logic/services/polling-inews-queue-watcher.ts
@@ -59,38 +59,41 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
 
   private async checkAndProcessQueue(queueId: string): Promise<void> {
     const inewsQueue: InewsQueue = this.getInewsQueue(queueId)
-    const storyCache: ReadonlyMap<string, InewsStory> = new Map(inewsQueue.stories.map(story => [story.id, story]))
+    const cachedStories: ReadonlyMap<string, InewsStory> = new Map(inewsQueue.stories.map(story => [story.id, story]))
     const storyMetadataSequence: readonly InewsStoryMetadata[] = await this.getStoryMetadataSequence(queueId)
 
     // Categorize
-    const metadataForNewStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForUncachedStories(storyMetadataSequence, storyCache)
-    const metadataForChangedStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForStoriesWithChangedContent(storyMetadataSequence, storyCache)
-    const metadataForMovedStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForMovedStories(storyMetadataSequence, storyCache)
-    const deletedStoryIds: readonly string[] = this.inewsQueueDiffer.getDeletedStoryIds(storyMetadataSequence, storyCache)
+    const metadataForNewStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForUncachedStories(storyMetadataSequence, cachedStories)
+    const metadataForChangedStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForStoriesWithChangedContent(storyMetadataSequence, cachedStories)
+    const metadataForMovedStories: readonly InewsStoryMetadata[] = this.inewsQueueDiffer.getMetadataForMovedStories(storyMetadataSequence, cachedStories)
+    const deletedStoryIds: readonly string[] = this.inewsQueueDiffer.getDeletedStoryIds(storyMetadataSequence, cachedStories)
 
     if (deletedStoryIds.length === 0 && metadataForNewStories.length === 0 && metadataForChangedStories.length === 0 && metadataForMovedStories.length === 0) {
       return
     }
 
     // Compute ranks
-    const updatedRanks: ReadonlyMap<string, number> = this.inewsStoryRankResolver.getInewsStoryRanks(storyMetadataSequence, storyCache)
+    const updatedRanks: ReadonlyMap<string, number> = this.computeInewsStoryRanks(storyMetadataSequence, cachedStories)
 
-    // Get stories
+    // Get stories with updated ranks
     const newStories: readonly InewsStory[] = (await this.getStories(queueId, metadataForNewStories)).map(story => ({ ...story, rank: updatedRanks.get(story.id) ?? 0 }))
     const changedStories: readonly InewsStory[] = (await this.getStories(queueId, metadataForChangedStories)).map(story => ({ ...story, rank: updatedRanks.get(story.id) ?? 0 }))
-    const movedStories: readonly InewsStory[] = metadataForMovedStories.map(storyMetadata => this.getInewsStoryWithUpdatedLocators(storyMetadata, storyCache)).map(story => ({ ...story, rank: updatedRanks.get(story.id) ?? 0 }))
+    const movedStories: readonly InewsStory[] = metadataForMovedStories.map(storyMetadata => this.getInewsStoryWithUpdatedLocators(storyMetadata, cachedStories)).map(story => ({ ...story, rank: updatedRanks.get(story.id) ?? 0 }))
+    const alteredAndDeletedStoryIds: ReadonlySet<string> = new Set(newStories.concat(changedStories).concat(movedStories).map(story => story.id).concat(deletedStoryIds))
+    const onlyRankUpdatedStories: readonly InewsStory[] = this.getStoriesAffectedByUpdatedRanks(cachedStories, updatedRanks, alteredAndDeletedStoryIds).map(story => ({ ...story, rank: updatedRanks.get(story.id) ?? 0 }))
 
     // Emit data
     deletedStoryIds.forEach(storyId => this.inewsQueueEmitter.emitDeletedInewsStory(queueId, storyId))
     changedStories.forEach(story => this.inewsQueueEmitter.emitChangedInewsStory(story))
     newStories.forEach(story => this.inewsQueueEmitter.emitCreatedInewsStory(story))
     movedStories.forEach(story => this.inewsQueueEmitter.emitMovedInewsStory(story))
+    onlyRankUpdatedStories.forEach(story => this.inewsQueueEmitter.emitMovedInewsStory(story))
 
     // Persist iNews queue
-    const alteredStories: Record<string, InewsStory> = Object.fromEntries(newStories.concat(changedStories).concat(movedStories).map(story => [story.id, story]))
+    const alteredStories: Record<string, InewsStory> = Object.fromEntries(newStories.concat(changedStories).concat(movedStories).concat(onlyRankUpdatedStories).map(story => [story.id, story]))
     this.inewsQueueRepository.setInewsQueue({
       ...inewsQueue,
-      stories: storyMetadataSequence.map(storyMetadata => alteredStories[storyMetadata.id] ?? storyCache.get(storyMetadata.id)!),
+      stories: storyMetadataSequence.map(storyMetadata => alteredStories[storyMetadata.id] ?? cachedStories.get(storyMetadata.id)!),
     })
   }
 
@@ -107,6 +110,11 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
 
   private getStoryMetadataSequence(queueId: string): Promise<readonly InewsStoryMetadata[]> {
     return this.inewsClient.getStoryMetadataForQueue(queueId)
+  }
+
+  private computeInewsStoryRanks(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): ReadonlyMap<string, number> {
+    // TODO: Measure the rank distance density and standard deviation to determine when to apply a reranking.
+    return this.inewsStoryRankResolver.getInewsStoryRanks(storyMetadataSequence, cachedStories)
   }
 
   private async getStories(queueId: string, storyMetadataCollection: readonly InewsStoryMetadata[]): Promise<readonly InewsStory[]> {
@@ -127,6 +135,10 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
       contentLocator: storyMetadata.contentLocator,
       versionLocator: storyMetadata.versionLocator,
     }
+  }
+
+  private getStoriesAffectedByUpdatedRanks(storyCache: ReadonlyMap<string, InewsStory>, ranks: ReadonlyMap<string, number>, alteredStoryIds: ReadonlySet<string>): readonly InewsStory[] {
+    return Array.from(storyCache.values()).filter(story => !alteredStoryIds.has(story.id) && ranks.get(story.id) && ranks.get(story.id) !== story.rank)
   }
 
   private clearPollingTimer(): void {

--- a/src/business-logic/services/polling-inews-queue-watcher.ts
+++ b/src/business-logic/services/polling-inews-queue-watcher.ts
@@ -73,7 +73,7 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
     }
 
     // Compute ranks
-    const updatedRanks: ReadonlyMap<string, number> = this.computeInewsStoryRanks(storyMetadataSequence, cachedStories)
+    const updatedRanks: ReadonlyMap<string, number> = this.inewsStoryRankResolver.getInewsStoryRanks(storyMetadataSequence, cachedStories)
 
     // Get stories with updated ranks
     const newStories: readonly InewsStory[] = (await this.getStories(queueId, metadataForNewStories)).map(story => ({ ...story, rank: updatedRanks.get(story.id) ?? 0 }))
@@ -110,11 +110,6 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
 
   private getStoryMetadataSequence(queueId: string): Promise<readonly InewsStoryMetadata[]> {
     return this.inewsClient.getStoryMetadataForQueue(queueId)
-  }
-
-  private computeInewsStoryRanks(storyMetadataSequence: readonly InewsStoryMetadata[], cachedStories: ReadonlyMap<string, InewsStory>): ReadonlyMap<string, number> {
-    // TODO: Measure the rank distance density and standard deviation to determine when to apply a reranking.
-    return this.inewsStoryRankResolver.getInewsStoryRanks(storyMetadataSequence, cachedStories)
   }
 
   private async getStories(queueId: string, storyMetadataCollection: readonly InewsStoryMetadata[]): Promise<readonly InewsStory[]> {


### PR DESCRIPTION
Improves the rank resolver by letting it use linear interpolation between untouched stories when a batch of touched stories are observed, along with allowing it to re-resolve all story ranks as if it was the first time, when the rank density becomes too high. The new implementation also adds the capability of increasing the ranks of untouched stories if the rank space is smaller than the ranks that should be assigned.

For the rank reset, the implementation takes a sample of the most dense ranks and computes the mean. If the mean is below a given threshold, then the ranks are computed without cached ranks. The sample size is currently set to 40 and and the threshold 15. These might need to be tweaked.

The `LogarithmicInewsStoryRankResolver` is renamed to `LinearInewsStoryRankResolver`, which has caused the implementation and the tests to marked as additions. The tests assertions are changed to test against the order of the elements rather than the concrete ranks. This ensures a higher degree of resistance to refactoring, e.g. changing the rate of growth does not affect the test assertions.
