### PR TITLE
Update readme with how to connect to the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The iNews Gateway application acts as an adapter for one or more iNews servers, 
 2. Configure _.env_ file. See [Configuration](#configuration).
 3. Start a development server with `yarn watch`. 
 
-# Configuration
+## Configuration
 
 The application can be configured with environment variables and a _.env_ file. The following snippet outlines the available configuration options.
 
@@ -38,3 +38,10 @@ EVENT_SERVER_PORT=3008
 # The number of milliseconds between fetching data from the iNews server(s). The default is 2000.
 INEWS_POLLING_INTERVAL_IN_MS=2000
 ```
+
+## Usage
+
+### Connecting to the WebSocket event server
+
+A WebSocket client connecting to the iNews Gateway for event observation, needs to specify the queues they want to observe in the query parameter.
+The queues should be specified as comma-separated list, e.g. `ws://inews-gateway:3008?queues=MY.FIRST.QUEUE,MY.SECOND.QUEUE,MY.THIRD.QUEUE`.

--- a/src/presentation/enums/websocket-close-code.ts
+++ b/src/presentation/enums/websocket-close-code.ts
@@ -1,0 +1,5 @@
+// Based on https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
+
+export enum WebsocketCloseCode {
+  UNSUPPORTED_DATA = 1003,
+}

--- a/src/presentation/services/websocket-server.ts
+++ b/src/presentation/services/websocket-server.ts
@@ -2,6 +2,7 @@ import * as ws from 'ws'
 import * as http from 'node:http'
 import { Logger } from '../../logger/logger'
 import { ClientConnectionServer, ConnectedCallback, DisconnectedCallback } from '../interfaces/client-connection-server'
+import { WebsocketCloseCode } from '../enums/websocket-close-code'
 
 export class WebsocketServer implements ClientConnectionServer {
   private httpServer?: http.Server
@@ -56,7 +57,7 @@ export class WebsocketServer implements ClientConnectionServer {
       this.connectedCallback?.(clientId, queryParameters)
     } catch (error: unknown) {
       this.logger.data(error).warn(`Failed registering client with client id '${clientId}'.`)
-      websocket.close()
+      websocket.close(WebsocketCloseCode.UNSUPPORTED_DATA, error instanceof Error ? error.message : `${error}`)
     }
   }
 


### PR DESCRIPTION
Updates README on how to connect to the application with a WebSocket.
Bonus: Adds close reason when failing to registering a client due to missing queues parameter.