### PR TITLE
SOF-1963: Add FTP disconnect reason

### DIFF
--- a/src/business-logic/interfaces/inews-client.ts
+++ b/src/business-logic/interfaces/inews-client.ts
@@ -8,5 +8,5 @@ export interface InewsClient {
   getStoryMetadataForQueue(queueId: string): Promise<readonly InewsStoryMetadata[]>
   getStory(queueId: string, inewsId: InewsId): Promise<InewsStory>
   subscribeToConnectionState(onConnectionStateChangedCallback: (connectionState: ConnectionState) => void): void
-  disconnect(): Promise<void>
+  disconnect(reason: string): Promise<void>
 }

--- a/src/business-logic/services/ftp-inews-client.ts
+++ b/src/business-logic/services/ftp-inews-client.ts
@@ -90,8 +90,8 @@ export class FtpInewsClient implements InewsClient {
     this.onConnectionStateChangedCallbacks.push(onConnectionStateChangedCallback)
   }
 
-  public async disconnect(): Promise<void> {
-    await this.ftpClient.disconnect()
+  public async disconnect(reason: string): Promise<void> {
+    await this.ftpClient.disconnect(reason)
     this.ftpClient.clearOnConnectionStateChangedCallback()
   }
 }

--- a/src/business-logic/services/polling-inews-queue-watcher.ts
+++ b/src/business-logic/services/polling-inews-queue-watcher.ts
@@ -139,6 +139,6 @@ export class PollingInewsQueueWatcher implements InewsQueueWatcher {
 
   public async stop(): Promise<void> {
     this.clearPollingTimer()
-    await this.inewsClient.disconnect()
+    await this.inewsClient.disconnect('Stopped polling iNews queue data.')
   }
 }

--- a/src/data-access/enums/connection-status.ts
+++ b/src/data-access/enums/connection-status.ts
@@ -1,5 +1,4 @@
 export enum ConnectionStatus {
-  CONNECTING = 'CONNECTING',
   CONNECTED = 'CONNECTED',
   DISCONNECTED = 'DISCONNECTED',
 }

--- a/src/data-access/interfaces/ftp-client.ts
+++ b/src/data-access/interfaces/ftp-client.ts
@@ -9,5 +9,5 @@ export interface FtpClient {
   getFile(filename: string): Promise<string>
   setOnConnectionStateChangedCallback(onConnectionStateChangedCallback: (connectionState: ConnectionState) => void): void
   clearOnConnectionStateChangedCallback(): void
-  disconnect(): Promise<void>
+  disconnect(reason: string): Promise<void>
 }

--- a/src/data-access/services/basic-ftp-ftp-client.ts
+++ b/src/data-access/services/basic-ftp-ftp-client.ts
@@ -23,8 +23,6 @@ export class BasicFtpFtpClient implements FtpClient {
 
   public async connect(): Promise<void> {
     try {
-      this.onConnectionStateChangedCallback?.({ status: ConnectionStatus.CONNECTING })
-
       await this.connectWithConfiguration()
 
       this.onConnectionStateChangedCallback?.({ status: ConnectionStatus.CONNECTED })

--- a/src/data-access/services/basic-ftp-ftp-client.ts
+++ b/src/data-access/services/basic-ftp-ftp-client.ts
@@ -92,12 +92,12 @@ export class BasicFtpFtpClient implements FtpClient {
     return (await fileStream.toArray()).join('')
   }
 
-  public async disconnect(): Promise<void> {
+  public async disconnect(reason: string): Promise<void> {
     if (!this.isConnected()) {
       return
     }
     this.ftpClient.close()
-    this.onConnectionStateChangedCallback?.({ status: ConnectionStatus.DISCONNECTED, message: `The connection to ${this.configuration.host}:${this.configuration.port} was closed.` })
+    this.onConnectionStateChangedCallback?.({ status: ConnectionStatus.DISCONNECTED, message: `The connection to ${this.configuration.host}:${this.configuration.port} was closed: ${reason}` })
     this.logger.info(`Disconnected from FTP server ${this.configuration.host}:${this.configuration.port}.`)
     return Promise.resolve()
   }

--- a/src/data-access/services/round-robin-ftp-client-pool.ts
+++ b/src/data-access/services/round-robin-ftp-client-pool.ts
@@ -27,7 +27,6 @@ export class RoundRobinFtpClientPool implements FtpClient {
 
   private async getFtpClientByRoundRobin(): Promise<FtpClient> {
     await this.disconnect()
-    this.emitConnectionState({ status: ConnectionStatus.CONNECTING })
 
     for (const ftpClient of this.ftpClients) {
       try {

--- a/src/data-access/services/round-robin-ftp-client-pool.ts
+++ b/src/data-access/services/round-robin-ftp-client-pool.ts
@@ -20,13 +20,13 @@ export class RoundRobinFtpClientPool implements FtpClient {
 
   private async getConnectedFtpClient(): Promise<FtpClient> {
     if (!this.connectedFtpClient?.isConnected()) {
-      this.connectedFtpClient = await this.getFtpClientByRoundRobin()
+      this.connectedFtpClient = await this.getFtpClientByRoundRobin('Connecting for the first time.')
     }
     return this.connectedFtpClient
   }
 
-  private async getFtpClientByRoundRobin(): Promise<FtpClient> {
-    await this.disconnect()
+  private async getFtpClientByRoundRobin(reason: string): Promise<FtpClient> {
+    await this.disconnect(reason)
 
     for (const ftpClient of this.ftpClients) {
       try {
@@ -75,7 +75,7 @@ export class RoundRobinFtpClientPool implements FtpClient {
       return
     }
     this.downPrioritizeConnectedFtpClient()
-    this.connectedFtpClient = await this.getFtpClientByRoundRobin()
+    this.connectedFtpClient = await this.getFtpClientByRoundRobin('The connection had too many failed operations.')
     this.failedOperationsTracker = 0
   }
 
@@ -110,9 +110,9 @@ export class RoundRobinFtpClientPool implements FtpClient {
     delete this.onConnectionStateChangedCallback
   }
 
-  public async disconnect(): Promise<void> {
+  public async disconnect(reason: string): Promise<void> {
     if (this.connectedFtpClient?.isConnected()) {
-      await this.connectedFtpClient?.disconnect()
+      await this.connectedFtpClient?.disconnect(reason)
     }
     this.connectedFtpClient?.clearOnConnectionStateChangedCallback()
   }

--- a/src/data-access/value-objects/connection-state.ts
+++ b/src/data-access/value-objects/connection-state.ts
@@ -1,13 +1,8 @@
 import { ConnectionStatus } from '../enums/connection-status'
 
 export type ConnectionState =
-  | ConnectingConnectionState
   | ConnectedConnectionState
   | DisconnectedConnectionState
-
-export interface ConnectingConnectionState {
-  readonly status: ConnectionStatus.CONNECTING
-}
 
 export interface ConnectedConnectionState {
   readonly status: ConnectionStatus.CONNECTED

--- a/src/presentation/services/client-event-server.ts
+++ b/src/presentation/services/client-event-server.ts
@@ -19,7 +19,7 @@ export class ClientEventServer implements EventServer {
   private lastConnectionStateEvent: ConnectionStateEvent = {
     type: ConnectionStateEventType.CONNECTION_STATE_UPDATED,
     status: ConnectionStatus.DISCONNECTED,
-    message: 'Unknown reason.',
+    message: 'Starting up...',
   }
 
   private readonly queueSubscriptions: Map<string, Set<string>> = new Map()

--- a/src/presentation/value-objects/connection-state-event.ts
+++ b/src/presentation/value-objects/connection-state-event.ts
@@ -3,13 +3,8 @@ import { ConnectionStateEventType } from '../enums/connection-state-event-type'
 import { ConnectionStatus } from '../../data-access/enums/connection-status'
 
 export type ConnectionStateEvent =
-  | ConnectingConnectionStateEvent
   | ConnectedConnectionStateEvent
   | DisconnectedConnectionStateEvent
-
-export interface ConnectingConnectionStateEvent extends TypedEvent<ConnectionStateEventType.CONNECTION_STATE_UPDATED> {
-  status: ConnectionStatus.CONNECTING
-}
 
 export interface ConnectedConnectionStateEvent extends TypedEvent<ConnectionStateEventType.CONNECTION_STATE_UPDATED> {
   status: ConnectionStatus.CONNECTED


### PR DESCRIPTION
The PR removes the connection status `CONNECTING`, since it overshadows the DISCONNECTED event with the reason for the disconnect.
When disconnect is called on an InewsClient or FtpClient, a reason is now required to improve the status message that the user receives.