### PR TITLE
SOF-1963: Increase FTP listing size to 10_000 and parse NSML meta tag attributes.

### DIFF
--- a/src/business-logic/services/ftp-inews-client.ts
+++ b/src/business-logic/services/ftp-inews-client.ts
@@ -10,6 +10,8 @@ import { InewsIdParser } from '../interfaces/inews-id-parser'
 import { InewsId } from '../entities/inews-id'
 import { Logger } from '../../logger/logger'
 
+const LISTING_SIZE: number = 10_000
+
 export class FtpInewsClient implements InewsClient {
   private readonly onConnectionStateChangedCallbacks: ((connectionState: ConnectionState) => void)[] = []
   private readonly logger: Logger
@@ -27,6 +29,7 @@ export class FtpInewsClient implements InewsClient {
   public async connect(): Promise<void> {
     this.ftpClient.setOnConnectionStateChangedCallback(connectionState => this.emitConnectionState(connectionState))
     await this.ftpClient.connect()
+    await this.ftpClient.setListingSize(LISTING_SIZE)
   }
 
   private emitConnectionState(connectionState: ConnectionState): void {

--- a/src/business-logic/services/nsml-inews-story-parser.spec.ts
+++ b/src/business-logic/services/nsml-inews-story-parser.spec.ts
@@ -145,6 +145,30 @@ describe(NsmlInewsStoryParser.name, () => {
       expect(result.versionLocator).toBe('22DDEEFF')
     })
   })
+
+  describe('when meta tag under head tag has attributes', () => {
+    it('puts these into the metadata attribute', () => {
+      const storyId: string = '001ea938'
+      const text: string = `<nsml version="some version 1.0"><head><meta rate=150 float wire mail><storyid>${storyId}:xxxxx:yyyyy</storyid></head><story><fields><f id=title>title</f></fields><body><p><a idref=0></p><p><cc>Comment</cc></p><p><pi>KAM 1</pi></p><p>MANUS</p></body><aeset><ae id=0><ap>First line=Foo</ap><ap>Second line = BAR</ap></ae></aeset></story>`
+      const inewsId: InewsId = EntityTestFactory.createInewsId({
+        storyId,
+        contentLocator: '11aabbcc',
+        versionLocator: '22ddeeff',
+      })
+      const expectedMetadata: Readonly<Record<string, string>> = {
+        title: 'title',
+        rate: '150',
+        float: 'float',
+        wire: 'wire',
+        mail: 'mail',
+      }
+      const testee: InewsStoryParser = createTestee()
+
+      const result: InewsStory = testee.parseInewsStory(text, 'queue-id', inewsId)
+
+      expect(result.metadata).toMatchObject(expectedMetadata)
+    })
+  })
 })
 
 function createTestee(): InewsStoryParser {

--- a/src/business-logic/services/nsml-inews-story-parser.ts
+++ b/src/business-logic/services/nsml-inews-story-parser.ts
@@ -21,7 +21,7 @@ export class NsmlInewsStoryParser implements InewsStoryParser {
       queueId,
       contentLocator: inewsId.contentLocator.toUpperCase(),
       versionLocator: inewsId.versionLocator.toUpperCase(),
-      metadata: this.formatMetadata(nsmlDocument.fields),
+      metadata: this.formatMetadata({ ...nsmlDocument.head, ...nsmlDocument.fields }),
       cues: this.mergeIntoCues(nsmlDocument.body, nsmlDocument.anchoredElements),
       rank: 0,
     }

--- a/src/business-logic/services/reg-exp-nsml-parser.spec.ts
+++ b/src/business-logic/services/reg-exp-nsml-parser.spec.ts
@@ -1,6 +1,6 @@
 import { RegExpNsmlParser } from './reg-exp-nsml-parser'
 import { NsmlParser } from '../interfaces/nsml-parser'
-import { NsmlDocument, NsmlParagraphType } from '../value-objects/nsml-document'
+import { NsmlDocument, NsmlHead, NsmlParagraphType } from '../value-objects/nsml-document'
 
 describe(RegExpNsmlParser.name, () => {
   describe('when nsml document has no anchored elements', () => {
@@ -38,9 +38,7 @@ describe(RegExpNsmlParser.name, () => {
         fields: { title },
         body: [
           {
-            type: NsmlParagraphType.CUE_REFERENCE,
-            cueId: '0',
-          },
+            type: NsmlParagraphType.CUE_REFERENCE, cueId: '0' },
           {
             type: NsmlParagraphType.COMMENT,
             text: 'Comment',
@@ -62,6 +60,24 @@ describe(RegExpNsmlParser.name, () => {
       const result: NsmlDocument = testee.parseNsmlDocument(text)
 
       expect(result).toMatchObject(expectedNsmlDocument)
+    })
+  })
+
+  describe('when meta tag under head tag has attributes', () => {
+    it('returns the attributes as tag under head', () => {
+      const text: string = '<nsml version="some version 1.0"><head><meta rate=150 float wire mail><storyid>some:story:id</storyid></head><story><fields><f id=title>title</f></fields><body><p><a idref=0></p><p><cc>Comment</cc></p><p><pi>KAM 1</pi></p><p>MANUS</p></body><aeset><ae id=0><ap>First line=Foo</ap><ap>Second line = BAR</ap></ae></aeset></story>'
+      const testee: NsmlParser = createTestee()
+      const expectedHead: NsmlHead = {
+        storyid: 'some:story:id',
+        rate: '150',
+        float: 'float',
+        wire: 'wire',
+        mail: 'mail',
+      }
+
+      const result: NsmlDocument = testee.parseNsmlDocument(text)
+
+      expect(result.head).toMatchObject(expectedHead)
     })
   })
 })

--- a/src/business-logic/value-objects/nsml-document.ts
+++ b/src/business-logic/value-objects/nsml-document.ts
@@ -10,6 +10,7 @@ export interface NsmlDocument {
 
 export interface NsmlHead {
   readonly storyid: string
+  readonly float?: 'float'
   readonly [key: string]: string
 }
 

--- a/src/data-access/interfaces/ftp-client.ts
+++ b/src/data-access/interfaces/ftp-client.ts
@@ -6,6 +6,7 @@ export interface FtpClient {
   isConnected(): boolean
   changeWorkingDirectory(path: string): Promise<void>
   listFiles(): Promise<readonly FileMetadata[]>
+  setListingSize(size: number): Promise<void>
   getFile(filename: string): Promise<string>
   setOnConnectionStateChangedCallback(onConnectionStateChangedCallback: (connectionState: ConnectionState) => void): void
   clearOnConnectionStateChangedCallback(): void

--- a/src/data-access/services/basic-ftp-ftp-client.ts
+++ b/src/data-access/services/basic-ftp-ftp-client.ts
@@ -80,6 +80,10 @@ export class BasicFtpFtpClient implements FtpClient {
     return fileInfos.map(fileInfo => this.mapToFileMetadata(fileInfo))
   }
 
+  public async setListingSize(listingSize: number): Promise<void> {
+    await this.ftpClient.send(`SITE LISTSZ=${listingSize}`)
+  }
+
   private mapToFileMetadata(fileInfo: basicFtp.FileInfo): FileMetadata {
     return {
       type: basicFtp.FileType[fileInfo.type].toLowerCase(),

--- a/src/data-access/services/round-robin-ftp-client-pool.ts
+++ b/src/data-access/services/round-robin-ftp-client-pool.ts
@@ -6,11 +6,13 @@ import { ConnectionState } from '../value-objects/connection-state'
 const MAX_FAILED_OPERATIONS_THRESHOLD: number = 20
 const SUCCESSFUL_OPERATION_WEIGHT: number = 1
 const FAILED_OPERATION_WEIGHT: number = 2
+const DEFAULT_LISTING_SIZE: number = 1000
 
 export class RoundRobinFtpClientPool implements FtpClient {
   private connectedFtpClient?: FtpClient
   private onConnectionStateChangedCallback?: (connectionState: ConnectionState) => void
   private failedOperationsTracker: number = 0
+  private listingSize: number = DEFAULT_LISTING_SIZE
 
   public constructor(private ftpClients: readonly FtpClient[]) {}
 
@@ -21,6 +23,7 @@ export class RoundRobinFtpClientPool implements FtpClient {
   private async getConnectedFtpClient(): Promise<FtpClient> {
     if (!this.connectedFtpClient?.isConnected()) {
       this.connectedFtpClient = await this.getFtpClientByRoundRobin()
+      await this.connectedFtpClient.setListingSize(this.listingSize)
     }
     return this.connectedFtpClient
   }
@@ -93,6 +96,14 @@ export class RoundRobinFtpClientPool implements FtpClient {
     return this.trackFailedOperations(async () => {
       const ftpClient: FtpClient = await this.getConnectedFtpClient()
       return ftpClient.listFiles()
+    })
+  }
+
+  public async setListingSize(listingSize: number): Promise<void> {
+    this.listingSize = listingSize
+    return this.trackFailedOperations(async () => {
+      const ftpClient: FtpClient = await this.getConnectedFtpClient()
+      return ftpClient.setListingSize(listingSize)
     })
   }
 

--- a/src/data-access/services/round-robin-ftp-client-pool.ts
+++ b/src/data-access/services/round-robin-ftp-client-pool.ts
@@ -23,7 +23,6 @@ export class RoundRobinFtpClientPool implements FtpClient {
   private async getConnectedFtpClient(): Promise<FtpClient> {
     if (!this.connectedFtpClient?.isConnected()) {
       this.connectedFtpClient = await this.getFtpClientByRoundRobin()
-      await this.connectedFtpClient.setListingSize(this.listingSize)
     }
     return this.connectedFtpClient
   }
@@ -35,6 +34,7 @@ export class RoundRobinFtpClientPool implements FtpClient {
     for (const ftpClient of this.ftpClients) {
       try {
         await ftpClient.connect()
+        await ftpClient.setListingSize(this.listingSize)
         this.emitConnectionState({ status: ConnectionStatus.CONNECTED })
         ftpClient.setOnConnectionStateChangedCallback(connectionState => this.emitConnectionState(connectionState))
         return ftpClient


### PR DESCRIPTION
The default listing size set by the iNews server connections are set to 500, which might leave out stories in large queues.
So this is changed to 10000.

While testing, I discovered that `float` was not exposed on the `InewsStory`. The parser now takes this into account.